### PR TITLE
feat: home nav cleanup and What you get strip

### DIFF
--- a/WORK_QUEUE.md
+++ b/WORK_QUEUE.md
@@ -8,7 +8,7 @@
 - Preserve `?src=...&camp=...&date=YYYYMMDD`.
 
 ## Queue
-- [ ] #6 Home: trim sections + nav cleanup
+- [x] #6 Home: trim sections + nav cleanup
 - [ ] #7 Home: First-90-Days block with countdown + slots
 - [ ] #8 Home: Milestones + Assignments strip
 - [ ] #9 Home: Payout readiness micro-panel

--- a/src/data/nav.ts
+++ b/src/data/nav.ts
@@ -13,11 +13,7 @@ export const NAV_PRIMARY: NavLink[] = [
 ];
 
 export const NAV_MORE: NavLink[] = [
-  { href: '/contests', label: 'Contests' },
-  { href: '/models', label: 'Models' },
   { href: '/case-studies', label: 'Case Studies' },
   { href: '/gear-kits', label: 'Gear kits' },
-  { href: '/starter-kit', label: 'StartRight kit' },
-  { href: '/startright', label: 'Join Models', prodHref: '/join-models' },
-  { href: '/claim', label: 'Claim' }
+  { href: '/starter-kit', label: 'StartRight kit' }
 ];

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -81,8 +81,16 @@ const resolveNavHref = (link) => {
 
 const moreMenuActive = moreNavLinks.some((link) => isNavActive(resolveNavHref(link)));
 
+const footerExtras = [
+  { href: '/contests', label: 'Contests' },
+  { href: '/models', label: 'Models' },
+  { href: '/join-models', label: 'Join Models' },
+  { href: '/claim', label: 'Claim' }
+];
+
 const footerLinks = [
   ...moreNavLinks,
+  ...footerExtras,
   { href: '/about', label: 'About' },
   { href: '/privacy', label: 'Privacy' },
   { href: '/terms', label: 'Terms' },

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,6 +5,7 @@ import Hero from '../partials/home/Hero.astro';
 import TrustedPrograms from '../partials/home/TrustedPrograms.astro';
 import HowItWorks from '../partials/home/HowItWorks.astro';
 import MiniTestimonials from '../partials/home/MiniTestimonials.astro';
+import WhatYouGet from '../partials/home/WhatYouGet.astro';
 
 const canonicalPath = Astro.url.pathname;
 
@@ -125,6 +126,7 @@ const websiteJsonLd = {
   <script type="application/ld+json" set:html={JSON.stringify(websiteJsonLd)} />
 
   <Hero />
+  <WhatYouGet />
   <TrustedPrograms />
   <HowItWorks />
   <MiniTestimonials />

--- a/src/partials/home/Hero.astro
+++ b/src/partials/home/Hero.astro
@@ -3,21 +3,9 @@ import LinkCTA from '../../components/LinkCTA.astro';
 import { HERO, PRIMARY_CTA } from '../../data/copy';
 import { withBase } from '../../utils/links';
 
-const highlightLinks = [
-  { href: '/case-studies', label: 'Proof vault updates' },
-  { href: '/models', label: 'Example builds' },
-  { href: '/about', label: 'Concierge touch' },
-  { href: '/blog', label: 'Blog preview' }
-] as const;
-
 const primaryCta = {
   label: PRIMARY_CTA.label,
   href: PRIMARY_CTA.pagesHref
-};
-
-const secondaryCta = {
-  label: 'Join models',
-  href: '/join-models'
 };
 ---
 <section class="relative isolate overflow-hidden px-6 pb-24 pt-20 sm:pb-28 sm:pt-24">
@@ -47,18 +35,10 @@ const secondaryCta = {
             prodHref={primaryCta.href}
             label={primaryCta.label}
           />
-          <LinkCTA
-            class="border border-white/15 bg-white/10 text-white/85 hover:bg-white/15"
-            pagesHref={secondaryCta.href}
-            prodHref={secondaryCta.href}
-            label={secondaryCta.label}
-          />
         </div>
-        <div class="flex flex-wrap gap-4 text-[clamp(0.8rem,1.4vw,0.9rem)] uppercase tracking-[0.35em] text-rose-gold/80">
-          {highlightLinks.map((link) => (
-            <a class="transition hover:text-white" href={withBase(link.href)}>{link.label}</a>
-          ))}
-        </div>
+        <p class="max-w-xl text-[clamp(0.82rem,1.6vw,0.95rem)] uppercase tracking-[0.32em] text-rose-gold/80">
+          StartRight unlocks the proof vault, example builds, and concierge desk in one place.
+        </p>
       </div>
       <div class="grid gap-6">
         <div class="relative overflow-hidden rounded-[34px] border border-white/10 bg-white/5 p-6 backdrop-blur">

--- a/src/partials/home/WhatYouGet.astro
+++ b/src/partials/home/WhatYouGet.astro
@@ -1,0 +1,48 @@
+---
+import { withBase } from '../../utils/links';
+
+const tiles = [
+  {
+    title: 'Proof vault + blog preview',
+    description:
+      'Peek at recent launch receipts and a rotating blog snippet so you know the tone, pacing, and scripts we’re iterating on.',
+    link: { href: '/case-studies', label: 'Explore proof vault' }
+  },
+  {
+    title: 'Example builds inside StartRight',
+    description:
+      'Borrow room flows, lighting notes, and offer stacks from curated example builds. Remix them once your kit unlocks.',
+    link: { href: '/models', label: 'See example builds' }
+  },
+  {
+    title: 'Concierge desk on standby',
+    description:
+      'Keep a concierge thread for boundary-friendly pacing, weekly check-ins, and refinement before you scale.',
+    link: { href: '/about', label: 'Meet the concierge' }
+  }
+] as const;
+---
+<section class="border-t border-white/5 bg-black/30 px-6 py-20">
+  <div class="mx-auto max-w-6xl">
+    <div class="flex flex-col gap-4 text-center">
+      <p class="mx-auto text-[clamp(0.75rem,1.2vw,0.9rem)] uppercase tracking-[0.4em] text-rose-petal/70">
+        What you get
+      </p>
+      <h2 class="font-display text-[clamp(2rem,4.5vw,2.9rem)] text-white">Proof, builds, and concierge in one strip</h2>
+      <p class="mx-auto max-w-3xl text-[clamp(0.95rem,1.9vw,1.15rem)] text-white/70">
+        Stop jumping between sections. StartRight keeps the proof vault, example builds, and concierge touchpoints together so you know exactly what unlocks after sign-up.
+      </p>
+    </div>
+    <div class="mt-12 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+      {tiles.map((tile) => (
+        <article class="flex h-full flex-col gap-4 rounded-3xl border border-white/10 bg-white/5 p-7">
+          <h3 class="font-display text-[clamp(1.4rem,3.2vw,1.9rem)] text-white">{tile.title}</h3>
+          <p class="text-[clamp(0.95rem,1.7vw,1.1rem)] leading-relaxed text-white/75">{tile.description}</p>
+          <a class="mt-auto inline-flex text-[clamp(0.78rem,1.4vw,0.9rem)] uppercase tracking-[0.35em] text-rose-gold transition hover:text-white" href={withBase(tile.link.href)}>
+            {tile.link.label}
+          </a>
+        </article>
+      ))}
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
## Summary
- remove Contests, Models, Join Models, and Claim from the primary navigation and surface them in the footer instead
- add a consolidated “What you get” three-tile strip covering proof vault, example builds, and concierge access
- simplify the home hero so StartRight is the only primary CTA while reinforcing what unlocks with the kit

## Testing
- npm ci *(fails: peer dependency conflict between @astrojs/tailwind@6.0.2 and tailwindcss@4.1.17; registry access also blocked when attempting to adjust versions)*
- npm run build *(fails: astro not found because dependencies are not installed due to the install failure)*
- grep -R "/go/" dist || true *(dist not present after failed build)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fa93c06888326abac39b629e3f519)