### PR TITLE
Add home milestones and payout readiness sections

### DIFF
--- a/WORK_QUEUE.md
+++ b/WORK_QUEUE.md
@@ -4,7 +4,7 @@
 ## Queue
 - [x] #12 Home: trim sections + nav cleanup
 - [x] #13 Home: First-90-Days block with countdown + slots
-- [ ] #14 Home: Milestones + Assignments strip
-- [ ] #15 Home: Payout readiness micro-panel
+- [x] #14 Home: Milestones + Assignments strip
+- [x] #15 Home: Payout readiness micro-panel
 - [ ] #16 VIP: teasers on Home + StartRight
 - [ ] #17 Gear: cohort urgency banner on /gear

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,9 +2,11 @@
 import SEO from '../components/SEO.astro';
 import MainLayout from '../layouts/MainLayout.astro';
 import Hero from '../partials/home/Hero.astro';
+import MilestonesStrip from '../partials/home/MilestonesStrip.astro';
 import TrustedPrograms from '../partials/home/TrustedPrograms.astro';
 import HowItWorks from '../partials/home/HowItWorks.astro';
 import MiniTestimonials from '../partials/home/MiniTestimonials.astro';
+import PayoutReadiness from '../partials/home/PayoutReadiness.astro';
 import WhatYouGet from '../partials/home/WhatYouGet.astro';
 import FirstNinetyDays from '../partials/home/FirstNinetyDays.astro';
 import { getCollection } from 'astro:content';
@@ -130,7 +132,9 @@ const websiteJsonLd = {
   <Hero />
   <WhatYouGet />
   <FirstNinetyDays />
+  <MilestonesStrip />
   <TrustedPrograms />
+  <PayoutReadiness />
   <HowItWorks />
   <MiniTestimonials />
 </MainLayout>

--- a/src/partials/home/MilestonesStrip.astro
+++ b/src/partials/home/MilestonesStrip.astro
@@ -1,0 +1,79 @@
+---
+const milestones = [
+  {
+    week: 'Week 1',
+    title: 'Proof + concierge intake',
+    assignment: 'Send your approval screenshot, confirm payout IDs, and set your concierge contact cadence.'
+  },
+  {
+    week: 'Week 2',
+    title: 'Launch rituals live',
+    assignment: 'Run the first themed segment, swap in boundary-safe upsells, and align overlays with your kit.'
+  },
+  {
+    week: 'Week 3',
+    title: 'Retention wiring',
+    assignment: 'Schedule VIP follow-ups, prep aftercare notes, and tune playlist cues that keep your room warm.'
+  },
+  {
+    week: 'Week 4',
+    title: 'Refinement + review',
+    assignment: 'Share results with concierge, rotate creative, and lock your re-run schedule for the next sprint.'
+  }
+];
+
+const progress = {
+  percent: 48,
+  label: 'Week 2 check-in — assignments on track'
+};
+---
+<section class="border-t border-white/5 bg-midnight/40 px-6 py-16">
+  <div class="mx-auto flex max-w-6xl flex-col gap-8">
+    <div class="flex flex-col gap-5 md:flex-row md:items-center md:justify-between">
+      <div class="space-y-3">
+        <p class="text-[clamp(0.75rem,1.2vw,0.9rem)] uppercase tracking-[0.4em] text-rose-petal/70">Milestones</p>
+        <h2 class="font-display text-[clamp(2rem,4vw,2.8rem)] text-white">Milestones + assignments strip</h2>
+        <p class="max-w-2xl text-[clamp(0.95rem,1.8vw,1.1rem)] text-white/70">
+          A four-week runway so you always know what ships next. These checkpoints stay light, with concierge adjusting your
+          scripts and pacing based on how your audience responds.
+        </p>
+      </div>
+      <div class="w-full max-w-sm space-y-3 rounded-3xl border border-white/10 bg-white/5 p-5 shadow-glow backdrop-blur">
+        <div class="flex items-center justify-between text-[clamp(0.85rem,1.5vw,1rem)] text-white/75">
+          <span>Progress</span>
+          <span class="font-semibold text-white">Week 2 of 4</span>
+        </div>
+        <div class="h-3 rounded-full bg-white/10">
+          <div
+            class="h-full rounded-full bg-gradient-to-r from-rose-gold via-rose-petal to-rose-gold"
+            style={`width: ${progress.percent}%`}
+            aria-hidden="true"
+          ></div>
+        </div>
+        <p class="text-[clamp(0.85rem,1.5vw,1rem)] text-white/75">{progress.label}</p>
+      </div>
+    </div>
+    <div
+      class="grid grid-flow-col gap-4 overflow-x-auto pb-3 md:grid-flow-row md:grid-cols-4 md:overflow-visible"
+      role="list"
+    >
+      {milestones.map((milestone, index) => (
+        <article
+          class="flex h-full min-w-[240px] flex-col gap-4 rounded-3xl border border-white/10 bg-white/5 p-6"
+          role="listitem"
+        >
+          <div class="flex items-center gap-3">
+            <span class="flex h-11 w-11 items-center justify-center rounded-full border border-white/20 bg-white/10 text-base font-semibold text-rose-gold">
+              {(index + 1).toString().padStart(2, '0')}
+            </span>
+            <div>
+              <p class="text-[clamp(0.8rem,1.4vw,0.95rem)] uppercase tracking-[0.35em] text-rose-petal/80">{milestone.week}</p>
+              <h3 class="font-display text-[clamp(1.25rem,2.6vw,1.6rem)] text-white">{milestone.title}</h3>
+            </div>
+          </div>
+          <p class="text-[clamp(0.95rem,1.7vw,1.1rem)] leading-relaxed text-white/75">{milestone.assignment}</p>
+        </article>
+      ))}
+    </div>
+  </div>
+</section>

--- a/src/partials/home/PayoutReadiness.astro
+++ b/src/partials/home/PayoutReadiness.astro
@@ -1,0 +1,51 @@
+---
+import { withBase } from '../../utils/links';
+
+const checklist = [
+  {
+    label: 'KYC ready',
+    description: 'Keep your ID and address docs handy so the partner portal clears compliance without delays.'
+  },
+  {
+    label: 'Payout method selected',
+    description: 'Review supported rails, thresholds, and fees before launch so your first deposits land where you want.',
+    href: '/earnings'
+  },
+  {
+    label: 'Test payout',
+    description: 'Send a small test once the account unlocks. Better to catch routing issues before a big push.'
+  }
+];
+---
+<section class="px-6 pb-20 pt-6">
+  <div class="mx-auto max-w-6xl">
+    <div class="flex flex-col gap-6 rounded-[28px] border border-white/10 bg-white/5 p-7 shadow-glow backdrop-blur md:flex-row md:items-center md:justify-between md:gap-10 md:p-8">
+      <div class="space-y-3">
+        <p class="text-[clamp(0.75rem,1.2vw,0.9rem)] uppercase tracking-[0.4em] text-rose-petal/70">Payout readiness</p>
+        <h3 class="font-display text-[clamp(1.8rem,3.8vw,2.4rem)] text-white">No payout stalls when you launch</h3>
+        <p class="max-w-2xl text-[clamp(0.95rem,1.8vw,1.1rem)] text-white/70">
+          Neutral, checklist-style prep so payouts flow smoothly. Keep the admin work light and focus on your room.
+        </p>
+      </div>
+      <div class="grid gap-3 md:min-w-[280px]">
+        {checklist.map((item) => (
+          <div class="flex items-start gap-3 rounded-2xl border border-white/10 bg-black/40 p-4">
+            <span class="mt-0.5 inline-flex h-7 w-7 items-center justify-center rounded-full border border-white/20 bg-white/10 text-[0.9rem] font-semibold text-rose-gold">
+              ✓
+            </span>
+            <div class="space-y-1">
+              <p class="text-[clamp(0.95rem,1.7vw,1.1rem)] font-semibold text-white">{item.label}</p>
+              {item.href ? (
+                <a class="text-[clamp(0.9rem,1.6vw,1.05rem)] text-rose-gold transition hover:text-white" href={withBase(item.href)}>
+                  {item.description}
+                </a>
+              ) : (
+                <p class="text-[clamp(0.9rem,1.6vw,1.05rem)] text-white/75">{item.description}</p>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
## Summary
- add a four-week milestones and assignments strip to the home page with progress indicator
- introduce payout readiness micro-panel checklist and hook into home layout
- mark queue items #14 and #15 as complete

## Testing
- `npm ci` *(fails: registry returns 403 for public packages)*
- `npm run build` *(fails: astro not installed because npm install could not complete)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fb495ab108326ace7989b23bf334e)