### PR TITLE
Add VIP teasers and gear cohort banner

### DIFF
--- a/WORK_QUEUE.md
+++ b/WORK_QUEUE.md
@@ -6,5 +6,5 @@
 - [x] #13 Home: First-90-Days block with countdown + slots
 - [x] #14 Home: Milestones + Assignments strip
 - [x] #15 Home: Payout readiness micro-panel
-- [ ] #16 VIP: teasers on Home + StartRight
-- [ ] #17 Gear: cohort urgency banner on /gear
+- [x] #16 VIP: teasers on Home + StartRight
+- [x] #17 Gear: cohort urgency banner on /gear

--- a/src/components/VipTeasers.astro
+++ b/src/components/VipTeasers.astro
@@ -1,0 +1,61 @@
+---
+import LinkCTA from './LinkCTA.astro';
+import { formatDateStamp } from '../utils/links';
+
+const claimHref = `/claim?src=vip_teaser&camp=vip&date=${formatDateStamp()}`;
+
+const tiles = [
+  {
+    title: 'VIP Kit',
+    summary:
+      'Concierge-guarded kit previews with lighting cues, pacing prompts, and white-glove onboarding notes reserved for high-touch partners.',
+    label: 'Launch support'
+  },
+  {
+    title: 'VIP Posts',
+    summary:
+      'Locked scripting feed for bespoke DM prompts and retention clips. Public visitors see teasers only—full drops unlock after verification.',
+    label: 'Retention fuel'
+  }
+];
+---
+<section class="px-6 pb-20 pt-4">
+  <div class="mx-auto max-w-6xl space-y-6 rounded-[34px] border border-rose-gold/30 bg-rose-gold/5 p-8 backdrop-blur-xl sm:p-10">
+    <div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+      <div class="space-y-2">
+        <p class="text-[clamp(0.75rem,1.2vw,0.9rem)] uppercase tracking-[0.4em] text-rose-gold/80">VIP program</p>
+        <h2 class="font-display text-[clamp(2.1rem,5vw,3rem)] text-white">Concierge-guarded VIP previews</h2>
+        <p class="max-w-3xl text-[clamp(0.95rem,1.8vw,1.1rem)] text-white/75">
+          Two private tracks sit behind the concierge gate. We share light teasers here; the full vault unlocks only after you verify with the team.
+        </p>
+      </div>
+      <div class="flex items-center gap-2 rounded-full border border-rose-gold/40 bg-rose-gold/10 px-4 py-2 text-sm uppercase tracking-[0.32em] text-rose-gold">
+        <span aria-hidden="true">✦</span>
+        <span>Locked by concierge</span>
+      </div>
+    </div>
+    <div class="grid gap-4 md:grid-cols-2">
+      {tiles.map((tile) => (
+        <article class="flex h-full flex-col justify-between gap-4 rounded-3xl border border-white/12 bg-white/5 p-6 shadow-inner shadow-black/20">
+          <div class="space-y-3">
+            <div class="flex flex-wrap items-center gap-2 text-[0.7rem] uppercase tracking-[0.32em] text-rose-petal/70">
+              <span class="rounded-full border border-white/15 px-3 py-1 text-white/70">Locked preview</span>
+              <span class="rounded-full border border-white/12 bg-white/5 px-3 py-1 text-white/60">{tile.label}</span>
+            </div>
+            <h3 class="font-display text-2xl text-white">{tile.title}</h3>
+            <p class="text-sm leading-relaxed text-white/70">{tile.summary}</p>
+          </div>
+          <div class="flex flex-wrap items-center gap-3 text-sm text-white/70">
+            <span class="rounded-full border border-white/15 px-3 py-1 text-[0.65rem] uppercase tracking-[0.3em] text-white/60">Teaser only</span>
+            <LinkCTA
+              class="border border-rose-gold/60 bg-rose-gold text-midnight shadow-glow"
+              pagesHref={claimHref}
+              prodHref={claimHref}
+              label="Unlock VIP"
+            />
+          </div>
+        </article>
+      ))}
+    </div>
+  </div>
+</section>

--- a/src/pages/gear-kits.astro
+++ b/src/pages/gear-kits.astro
@@ -7,6 +7,20 @@ import { gearKits } from '../data/gear-kits';
 
 const heroDescription =
   'Pick the hardware stack that matches your room, budget, and concierge goals. These kits are field-tested inside StartRight so you launch with reliable lighting, clean audio, and an intentional backdrop.';
+
+const targetDate = new Date('2025-12-31T00:00:00Z');
+const now = new Date();
+const diff = Math.max(targetDate.getTime() - now.getTime(), 0);
+const dayMs = 1000 * 60 * 60 * 24;
+const hourMs = 1000 * 60 * 60;
+const minuteMs = 1000 * 60;
+const countdown = {
+  days: Math.floor(diff / dayMs),
+  hours: Math.floor((diff % dayMs) / hourMs),
+  minutes: Math.floor((diff % hourMs) / minuteMs)
+};
+
+const cohort = { current: 12, total: 28 };
 ---
 
 <MainLayout
@@ -15,6 +29,33 @@ const heroDescription =
 >
   <section class="space-y-8">
     <Notices />
+    <div class="rounded-[28px] border border-rose-gold/40 bg-rose-gold/10 p-6 backdrop-blur-xl sm:p-7">
+      <div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+        <div class="space-y-2">
+          <p class="text-[0.75rem] uppercase tracking-[0.35em] text-rose-gold/80">Gear cohort</p>
+          <h2 class="font-display text-2xl text-white sm:text-3xl">Reserve your concierge calibration slot</h2>
+          <p class="max-w-3xl text-sm text-white/70">
+            We stage each upgrade in limited batches so lighting, audio, and automation stay aligned with your StartRight rituals.
+            Claim a slot before the intake closes.
+          </p>
+        </div>
+        <div class="flex flex-wrap items-center gap-3 text-xs uppercase tracking-[0.32em] text-white/80">
+          <span class="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/5 px-4 py-2 text-white">
+            <span class="text-rose-gold">⏳</span>
+            {countdown.days}d {countdown.hours}h {countdown.minutes}m
+          </span>
+          <span class="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/5 px-4 py-2 text-white">
+            {cohort.current}/{cohort.total} slots filled
+          </span>
+          <span
+            data-gear-vip-badge
+            class="hidden items-center gap-2 rounded-full border border-rose-gold/60 bg-rose-gold/15 px-4 py-2 text-rose-gold"
+          >
+            VIP priority
+          </span>
+        </div>
+      </div>
+    </div>
     <div class="content-card space-y-6">
       <span class="hero-tagline">StartRight gear concierge</span>
       <h1 class="font-display text-4xl text-white sm:text-5xl">Gear kits for every launch stage</h1>
@@ -107,4 +148,14 @@ const heroDescription =
       </p>
     </section>
   </section>
+  <script is:inline>
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('vip') === '1') {
+      const badge = document.querySelector('[data-gear-vip-badge]');
+      if (badge) {
+        badge.classList.remove('hidden');
+        badge.classList.add('inline-flex');
+      }
+    }
+  </script>
 </MainLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,6 +9,7 @@ import MiniTestimonials from '../partials/home/MiniTestimonials.astro';
 import PayoutReadiness from '../partials/home/PayoutReadiness.astro';
 import WhatYouGet from '../partials/home/WhatYouGet.astro';
 import FirstNinetyDays from '../partials/home/FirstNinetyDays.astro';
+import VipTeasers from '../components/VipTeasers.astro';
 import { getCollection } from 'astro:content';
 
 const canonicalPath = Astro.url.pathname;
@@ -135,6 +136,7 @@ const websiteJsonLd = {
   <MilestonesStrip />
   <TrustedPrograms />
   <PayoutReadiness />
+  <VipTeasers />
   <HowItWorks />
   <MiniTestimonials />
 </MainLayout>

--- a/src/pages/startright.astro
+++ b/src/pages/startright.astro
@@ -3,6 +3,7 @@ import LinkCTA from '../components/LinkCTA.astro';
 import Notices from '../components/Notices.astro';
 import SEO from '../components/SEO.astro';
 import MainLayout from '../layouts/MainLayout.astro';
+import VipTeasers from '../components/VipTeasers.astro';
 import { HERO, PRIMARY_CTA, STARTRIGHT_SKIP } from '../data/copy';
 import { gearKits } from '../data/gear-kits';
 import programs from '../data/programs.json';
@@ -347,6 +348,7 @@ const clientPrograms = JSON.stringify(
       </p>
     </section>
   </section>
+  <VipTeasers />
   <section class="content-card space-y-6">
     <div class="space-y-3">
       <h2 class="section-heading">StartRight gear concierge</h2>


### PR DESCRIPTION
## Summary
- add a reusable VIP teaser module and surface it on the home and StartRight pages with the guarded unlock CTA
- introduce a cohort urgency banner on the gear kits page with countdown, slot counter, and VIP badge toggle
- mark queue items #16 and #17 as completed in WORK_QUEUE.md

## Testing
- npm ci *(fails: registry.npmjs.org returns 403 Forbidden; network access to npm registry is blocked in this environment)*
- npm run build *(fails: astro not found because npm dependencies could not be installed due to the registry 403)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fb719711c83269317bf6553b3d51e)