### PR TITLE
feat: placeholder banner registry and safe placements

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",
-    "build:pages": "astro build --config astro.config.pages.mjs",
+    "build:pages": "IS_PAGES=true astro build --config astro.config.pages.mjs",
     "preview": "astro preview",
     "test": "node --test --test-concurrency=1 \"tests/**/*.mjs\" && vitest run",
     "test:pages-safety": "node scripts/test-pages-safety.mjs",

--- a/public/placeholders/banner-300x250.svg
+++ b/public/placeholders/banner-300x250.svg
@@ -1,0 +1,6 @@
+<svg width="300" height="250" viewBox="0 0 300 250" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="300" height="250" rx="16" fill="#0F172A" stroke="#F3E8FF" stroke-dasharray="8 8" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="#F3E8FF" font-family="'Inter', sans-serif" font-size="16">
+    300x250 Placeholder Banner
+  </text>
+</svg>

--- a/public/placeholders/banner-728x90.svg
+++ b/public/placeholders/banner-728x90.svg
@@ -1,0 +1,6 @@
+<svg width="728" height="90" viewBox="0 0 728 90" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="728" height="90" rx="12" fill="#0F172A" stroke="#F3E8FF" stroke-dasharray="8 8" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="#F3E8FF" font-family="'Inter', sans-serif" font-size="18">
+    728x90 Placeholder Banner
+  </text>
+</svg>

--- a/src/components/BannerSlot.astro
+++ b/src/components/BannerSlot.astro
@@ -1,75 +1,43 @@
 ---
-import LinkCTA from './LinkCTA.astro';
-import { BANNERS, getBannerSlot, type BannerSlotId } from '../data/banners';
-import { formatDateStamp, withBase } from '../utils/links';
+import { banners, type Banner } from '../data/banners';
+import { withBase } from '../utils/links';
 
 interface Props {
-  id: BannerSlotId;
+  id: Banner['id'];
   class?: string;
-  showNote?: boolean;
+  placement?: string;
 }
 
-const { id, class: className = '', showNote = false } = Astro.props as Props;
-const slot = getBannerSlot(id);
+const { id, class: className = '', placement } = Astro.props as Props;
 
-if (!slot) {
-  const available = Object.keys(BANNERS).join(', ');
+const banner = banners.find((entry) => entry.id === id);
+
+if (!banner) {
+  const available = banners.map((entry) => entry.id).join(', ');
   throw new Error(`Banner slot "${id}" is not defined. Available slots: ${available}`);
 }
 
-const resolveHostname = (value: string | undefined) => {
-  if (!value) {
-    return '';
-  }
-
-  try {
-    return new URL(value).hostname;
-  } catch {
-    return String(value).replace(/^https?:\/\//, '').split('/')[0];
-  }
-};
-
-const siteHostname = resolveHostname(import.meta.env.SITE as string | undefined);
 const isPagesBuild = import.meta.env.IS_PAGES === 'true';
-const isProdSite = siteHostname === 'naughtycamspot.com';
-const shouldTrackClicks = isProdSite && !isPagesBuild;
+const isGoSlug = banner.href.startsWith('/go/');
+const safeHref = isPagesBuild && isGoSlug ? '/join-models' : banner.href;
+const anchorHref = withBase(safeHref);
+const imgSrc = withBase(banner.img);
 
-const hydrateProdHref = (value: string) => value.replace('YYYYMMDD', formatDateStamp());
-
-const hrefPages = slot.href_pages;
-const hrefProd = hydrateProdHref(slot.href_prod);
 const anchorClass = [
   'banner-slot block overflow-hidden rounded-3xl border border-white/10 bg-white/5 p-3 text-center shadow-glow transition hover:-translate-y-1',
   className
 ]
   .filter(Boolean)
   .join(' ');
-
-const imageSrc = slot.img.startsWith('http') ? slot.img : withBase(slot.img);
-const rel = 'sponsored';
 ---
-<div class="space-y-3">
-  <LinkCTA
-    class={anchorClass}
-    pagesHref={hrefPages}
-    prodHref={hrefProd}
-    label={slot.alt}
-    rel={rel}
-    data-track={shouldTrackClicks ? 'click' : undefined}
-    data-slot={shouldTrackClicks ? id : undefined}
-    data-camp={shouldTrackClicks ? 'banner' : undefined}
-  >
-    <img
-      src={imageSrc}
-      alt={slot.alt}
-      width={slot.size.w}
-      height={slot.size.h}
-      loading="lazy"
-      decoding="async"
-      class="h-auto w-full object-cover"
-    />
-  </LinkCTA>
-  {showNote && slot.note && (
-    <p class="text-xs uppercase tracking-[0.3em] text-white/45">{slot.note}</p>
-  )}
-</div>
+<a class={anchorClass} href={anchorHref} aria-label={banner.alt} data-placement={placement}>
+  <img
+    src={imgSrc}
+    alt={banner.alt}
+    width={banner.width}
+    height={banner.height}
+    loading="lazy"
+    decoding="async"
+    class="h-auto w-full object-cover"
+  />
+</a>

--- a/src/components/LinkCTA.astro
+++ b/src/components/LinkCTA.astro
@@ -30,7 +30,11 @@ const resolvedProdHref = typeof prodHref === 'string' && prodHref.trim().length 
 
 const baseUrl = typeof import.meta.env.BASE_URL === 'string' ? import.meta.env.BASE_URL : '/';
 const isPagesFlag = typeof import.meta.env.IS_PAGES === 'string' ? import.meta.env.IS_PAGES === 'true' : false;
-const isPagesBuild = isPagesFlag || baseUrl !== '/';
+const isPagesProcessFlag =
+  typeof process !== 'undefined' && typeof process.env?.IS_PAGES === 'string'
+    ? process.env.IS_PAGES === 'true'
+    : false;
+const isPagesBuild = isPagesFlag || isPagesProcessFlag || baseUrl !== '/';
 const candidateHref = isPagesBuild ? (resolvedPagesHref ?? resolvedProdHref) : (resolvedProdHref ?? resolvedPagesHref);
 const rawHref = candidateHref ?? '';
 const trimmedHref = typeof rawHref === 'string' ? rawHref.trim() : '';

--- a/src/data/banners.ts
+++ b/src/data/banners.ts
@@ -1,50 +1,27 @@
-import { DISCLOSURE } from './copy';
+export interface Banner {
+  id: string;
+  width: number;
+  height: number;
+  img: string;
+  alt: string;
+  href: string; // will point to internal `/go/*` slugs later
+}
 
-export const BANNERS = {
-  home_top_leaderboard: {
-    img: '/ads/leaderboard-970x90.svg',
-    alt: 'Start camming — get the free 14-day kit',
-    href_pages: '/startright',
-    href_prod: '/go/model-join.php?src=banner_home_top&camp=home&date=YYYYMMDD',
-    size: { w: 970, h: 90 },
-    note: DISCLOSURE
+export const banners: Banner[] = [
+  {
+    id: 'placeholder-wide',
+    width: 728,
+    height: 90,
+    img: '/placeholders/banner-728x90.svg',
+    alt: 'Ad banner',
+    href: '/join-models'
   },
-  model_sidebar_tall: {
-    img: '/ads/sky-160x600.svg',
-    alt: 'Join with our links',
-    href_pages: '/startright',
-    href_prod: '/go/model-join.php?src=banner_model_sidebar&camp=model&date=YYYYMMDD',
-    size: { w: 160, h: 600 },
-    note: DISCLOSURE
-  },
-  model_mid_rectangle: {
-    img: '/ads/model_mid_rectangle.svg',
-    alt: 'Concierge-guided cam onboarding — unlock now',
-    href_pages: '/startright',
-    href_prod: '/go/model-join.php?src=banner_model_mid&camp=model&date=YYYYMMDD',
-    size: { w: 300, h: 250 },
-    note: DISCLOSURE
-  },
-  post_inline_rect: {
-    img: '/ads/rect-300x250.svg',
-    alt: 'Claim your StartRight kit',
-    href_pages: '/startright',
-    href_prod: '/startright',
-    size: { w: 300, h: 250 },
-    note: 'Free 14-day kit after signup proof.'
-  },
-  post_end_strip: {
-    img: '/ads/post_end_strip.svg',
-    alt: 'Finish with the StartRight concierge plan',
-    href_pages: '/startright',
-    href_prod: '/go/model-join.php?src=banner_blog_end&camp=blog&date=YYYYMMDD',
-    size: { w: 900, h: 200 },
-    note: DISCLOSURE
+  {
+    id: 'placeholder-rect',
+    width: 300,
+    height: 250,
+    img: '/placeholders/banner-300x250.svg',
+    alt: 'Ad banner',
+    href: '/join-models'
   }
-} as const;
-
-export type BannerSlotId = keyof typeof BANNERS;
-
-export type BannerConfig = (typeof BANNERS)[BannerSlotId];
-
-export const getBannerSlot = (id: BannerSlotId) => BANNERS[id];
+];

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -28,6 +28,12 @@ export async function getStaticPaths() {
 const { post, related } = Astro.props;
 const { Content } = await post.render();
 
+const firstParagraph =
+  post.body
+    .split(/\n\s*\n/)
+    .map((block) => block.trim())
+    .find((block) => block && !block.startsWith('#')) ?? post.data.description ?? '';
+
 const isPages = import.meta.env.IS_PAGES === 'true';
 const trackingQuery = new URLSearchParams({
   src: `blog_${post.slug}`,
@@ -76,12 +82,18 @@ const startRightMessage = isPages
       <img src={post.data.heroImage} alt={post.data.heroImageAlt ?? post.data.title} class="h-80 w-full object-cover" loading="lazy" />
     </div>
 
-    <div class="space-y-6 text-base leading-relaxed text-white/70">
+    {firstParagraph && (
+      <div class="space-y-6 text-base leading-relaxed text-white/70">
+        <p>{firstParagraph}</p>
+        <div class="mt-6">
+          <BannerSlot id="placeholder-rect" class="w-full" placement={`blog-inline-${post.slug}`} />
+        </div>
+      </div>
+    )}
+
+    <div class="article-body space-y-6 text-base leading-relaxed text-white/70">
       <Content />
     </div>
-
-    <!-- SLOT: post_inline_rect -->
-    <BannerSlot id="post_inline_rect" class="mt-6" showNote />
 
     <div class="content-card space-y-5">
       <h2 class="text-xs uppercase tracking-[0.35em] text-rose-petal/70">Continue your launch</h2>
@@ -104,9 +116,6 @@ const startRightMessage = isPages
     </div>
   </article>
 
-  <!-- SLOT: post_end_strip -->
-  <BannerSlot id="post_end_strip" class="mt-16" showNote />
-
   <!-- SECTION: Related Posts -->
   <section class="space-y-6">
     <h2 class="section-heading">Related Posts</h2>
@@ -123,4 +132,10 @@ const startRightMessage = isPages
       ))}
     </div>
   </section>
+
+  <style>
+    .article-body > p:first-of-type {
+      display: none;
+    }
+  </style>
 </MainLayout>

--- a/src/pages/compare.astro
+++ b/src/pages/compare.astro
@@ -72,8 +72,6 @@ const programCards: ProgramCard[] = enrichedPrograms
 
 <MainLayout title="Compare cam platforms" description="Compare cam platforms tailored for new creators launching with NaughtyCamSpot.">
   <Hero />
-  <!-- SLOT: home_top_leaderboard -->
-  <BannerSlot id="home_top_leaderboard" class="mx-auto max-w-full" />
   <section class="space-y-8">
     <Notices />
     <div class="space-y-4">
@@ -82,6 +80,9 @@ const programCards: ProgramCard[] = enrichedPrograms
         These quick-reference cards show our current onboarding guardrails. Use them to decide where to launch, then join via the
         guarded links so we can ship your StartRight kit.
       </p>
+    </div>
+    <div class="flex justify-center">
+      <BannerSlot id="placeholder-wide" class="max-w-full" placement="compare-platform-breakdown" />
     </div>
     <div class="grid gap-8 lg:grid-cols-3">
       {programCards.map((program) => (

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,6 +10,7 @@ import PayoutReadiness from '../partials/home/PayoutReadiness.astro';
 import WhatYouGet from '../partials/home/WhatYouGet.astro';
 import FirstNinetyDays from '../partials/home/FirstNinetyDays.astro';
 import VipTeasers from '../components/VipTeasers.astro';
+import BannerSlot from '../components/BannerSlot.astro';
 import { getCollection } from 'astro:content';
 
 const canonicalPath = Astro.url.pathname;
@@ -132,6 +133,9 @@ const websiteJsonLd = {
 
   <Hero />
   <WhatYouGet />
+  <div class="my-12 flex justify-center">
+    <BannerSlot id="placeholder-wide" class="max-w-full" placement="home-what-you-get" />
+  </div>
   <FirstNinetyDays />
   <MilestonesStrip />
   <TrustedPrograms />

--- a/src/pages/models/[slug].astro
+++ b/src/pages/models/[slug].astro
@@ -1,5 +1,4 @@
 ---
-import BannerSlot from '../../components/BannerSlot.astro';
 import LinkCTA from '../../components/LinkCTA.astro';
 import Notices from '../../components/Notices.astro';
 import MainLayout from '../../layouts/MainLayout.astro';
@@ -125,10 +124,6 @@ const jsonLd = {
         <div class="overflow-hidden rounded-[28px] border border-white/10 bg-white/5">
           <img class="h-72 w-full object-cover" src={data.heroImage} alt={data.name} loading="lazy" />
         </div>
-        <!-- SLOT: model_sidebar_tall -->
-        <BannerSlot id="model_sidebar_tall" class="w-full" />
-        <!-- SLOT: model_mid_rectangle -->
-        <BannerSlot id="model_mid_rectangle" class="w-full" />
         <div class="rounded-3xl border border-white/10 bg-white/5 p-4 text-sm text-white/65 backdrop-blur">
           <p class="mb-2 text-xs uppercase tracking-[0.35em] text-rose-petal/70">Profiles</p>
           <ul class="space-y-2">

--- a/src/pages/models/index.astro
+++ b/src/pages/models/index.astro
@@ -1,5 +1,4 @@
 ---
-import BannerSlot from '../../components/BannerSlot.astro';
 import LinkCTA from '../../components/LinkCTA.astro';
 import Notices from '../../components/Notices.astro';
 import MainLayout from '../../layouts/MainLayout.astro';
@@ -71,8 +70,6 @@ const rangeLabels: Record<string, string> = {
       </div>
 
       <aside class="space-y-4">
-        <!-- SLOT: model_sidebar_tall -->
-        <BannerSlot id="model_sidebar_tall" class="w-full" />
         <div class="rounded-3xl border border-white/10 bg-white/5 p-5 backdrop-blur">
           <h3 class="font-display text-xl text-white">Need a concierge walkthrough?</h3>
           <p class="mt-2 text-sm text-white/70">

--- a/tests/banners.test.ts
+++ b/tests/banners.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { execSync } from 'node:child_process';
+import { banners } from '../src/data/banners';
+
+const distDir = path.resolve('dist');
+
+const readHtml = (relativePath: string) => fs.readFileSync(path.join(distDir, relativePath), 'utf8');
+
+const collectHtmlFiles = (dir: string): string[] => {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+
+  return entries.flatMap((entry) => {
+    const resolved = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      return collectHtmlFiles(resolved);
+    }
+    return entry.name.endsWith('.html') ? [resolved] : [];
+  });
+};
+
+beforeAll(() => {
+  execSync('npm run build:pages', { stdio: 'inherit' });
+});
+
+describe('banner registry', () => {
+  it('loads without throwing and contains valid entries', () => {
+    expect(banners.length).toBeGreaterThan(0);
+
+    for (const banner of banners) {
+      expect(banner.id).toBeTypeOf('string');
+      expect(banner.width).toBeGreaterThan(0);
+      expect(banner.height).toBeGreaterThan(0);
+      expect(banner.img).toMatch(/\.svg$/);
+      expect(banner.href).toBeTruthy();
+    }
+  });
+});
+
+describe('pages build safety', () => {
+  it('does not emit /go/ links in Pages builds', () => {
+    const htmlFiles = collectHtmlFiles(distDir);
+    const contents = htmlFiles.map((filePath) => fs.readFileSync(filePath, 'utf8'));
+
+    for (const content of contents) {
+      expect(content).not.toContain('/go/');
+    }
+  });
+
+  it('renders placeholder banners on target pages', () => {
+    const homeHtml = readHtml('index.html');
+    const compareHtml = readHtml(path.join('compare', 'index.html'));
+
+    expect(homeHtml).toContain('/placeholders/banner-728x90.svg');
+    expect(compareHtml).toContain('/placeholders/banner-728x90.svg');
+
+    const blogDir = path.join(distDir, 'blog');
+    const blogEntries = fs
+      .readdirSync(blogDir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name);
+
+    expect(blogEntries.length).toBeGreaterThan(0);
+
+    const firstBlog = blogEntries[0];
+    const blogHtml = readHtml(path.join('blog', firstBlog, 'index.html'));
+
+    expect(blogHtml).toContain('/placeholders/banner-300x250.svg');
+  });
+});


### PR DESCRIPTION
## Summary
- add a placeholder banner registry with reusable BannerSlot component and responsive assets
- place safe placeholder banners on home, compare, and blog pages while guarding Pages builds from `/go/` links
- extend LinkCTA and test coverage to enforce safe links and validate banner renderings

## Testing
- npm ci
- npm test
- npm run build:pages
- grep -R "/go/" dist || echo OK


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ff98e899c8326aa95b9dde5b4a0c5)