### PR TITLE
[#27] Harden banner placements

### DIFF
--- a/WORK_QUEUE.md
+++ b/WORK_QUEUE.md
@@ -12,7 +12,7 @@
 
 ## Queue
 - [x] #26 Programs registry hardening + tests
-- [ ] #27 Banners: data + safe placements
+- [x] #27 Banners: data + safe placements
 - [ ] #28 Gear Kits V0 (curated, compliant)
 - [ ] #29 StartRight: choose V0 static wizard or fold into page
 - [ ] #30 Content fill: core pages

--- a/src/components/BannerSlot.astro
+++ b/src/components/BannerSlot.astro
@@ -18,9 +18,12 @@ if (!banner) {
 }
 
 const isPagesBuild = import.meta.env.IS_PAGES === 'true';
+const baseUrl = typeof import.meta.env.BASE_URL === 'string' ? import.meta.env.BASE_URL : '/';
 const isGoSlug = banner.href.startsWith('/go/');
 const safeHref = isPagesBuild && isGoSlug ? '/join-models' : banner.href;
-const anchorHref = withBase(safeHref);
+const isAbsoluteHref = /^https?:\/\//i.test(safeHref);
+const hasBasePrefix = !isAbsoluteHref && typeof baseUrl === 'string' && baseUrl !== '/' && safeHref.startsWith(baseUrl);
+const anchorHref = isAbsoluteHref || hasBasePrefix ? safeHref : withBase(safeHref);
 const imgSrc = withBase(banner.img);
 
 const anchorClass = [

--- a/src/data/banners.ts
+++ b/src/data/banners.ts
@@ -1,27 +1,63 @@
+import { buildTrackedLink } from '../utils/links';
+
 export interface Banner {
   id: string;
   width: number;
   height: number;
   img: string;
   alt: string;
-  href: string; // will point to internal `/go/*` slugs later
+  href: string;
 }
 
-export const banners: Banner[] = [
+type BannerDefinition = Omit<Banner, 'href'> & {
+  path: string;
+  slot: string;
+  camp: string;
+  placeholder?: string;
+};
+
+const definitions: BannerDefinition[] = [
   {
-    id: 'placeholder-wide',
+    id: 'home_top_leaderboard',
     width: 728,
     height: 90,
     img: '/placeholders/banner-728x90.svg',
-    alt: 'Ad banner',
-    href: '/join-models'
+    alt: 'Route your signup through StartRight concierge',
+    path: '/go/model-join.php',
+    slot: 'home_top_leaderboard',
+    camp: 'home',
+    placeholder: '/startright'
   },
   {
-    id: 'placeholder-rect',
+    id: 'compare_top_leaderboard',
+    width: 728,
+    height: 90,
+    img: '/placeholders/banner-728x90.svg',
+    alt: 'Guarded onboarding links for compare readers',
+    path: '/go/model-join.php',
+    slot: 'compare_top_leaderboard',
+    camp: 'compare',
+    placeholder: '/startright'
+  },
+  {
+    id: 'blog_inline_rect',
     width: 300,
     height: 250,
     img: '/placeholders/banner-300x250.svg',
-    alt: 'Ad banner',
-    href: '/join-models'
+    alt: 'Unlock the StartRight concierge kit',
+    path: '/go/model-join.php',
+    slot: 'blog_inline_rect',
+    camp: 'blog',
+    placeholder: '/startright'
   }
 ];
+
+export const banners: Banner[] = definitions.map(({ path, slot, camp, placeholder, ...rest }) => ({
+  ...rest,
+  href: buildTrackedLink({
+    path,
+    slot,
+    camp,
+    placeholder: placeholder ?? '/startright'
+  })
+}));

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -86,7 +86,7 @@ const startRightMessage = isPages
       <div class="space-y-6 text-base leading-relaxed text-white/70">
         <p>{firstParagraph}</p>
         <div class="mt-6">
-          <BannerSlot id="placeholder-rect" class="w-full" placement={`blog-inline-${post.slug}`} />
+          <BannerSlot id="blog_inline_rect" class="w-full" placement={`blog-inline-${post.slug}`} />
         </div>
       </div>
     )}

--- a/src/pages/compare.astro
+++ b/src/pages/compare.astro
@@ -82,7 +82,7 @@ const programCards: ProgramCard[] = enrichedPrograms
       </p>
     </div>
     <div class="flex justify-center">
-      <BannerSlot id="placeholder-wide" class="max-w-full" placement="compare-platform-breakdown" />
+      <BannerSlot id="compare_top_leaderboard" class="max-w-full" placement="compare-platform-breakdown" />
     </div>
     <div class="grid gap-8 lg:grid-cols-3">
       {programCards.map((program) => (

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -134,7 +134,7 @@ const websiteJsonLd = {
   <Hero />
   <WhatYouGet />
   <div class="my-12 flex justify-center">
-    <BannerSlot id="placeholder-wide" class="max-w-full" placement="home-what-you-get" />
+    <BannerSlot id="home_top_leaderboard" class="max-w-full" placement="home-what-you-get" />
   </div>
   <FirstNinetyDays />
   <MilestonesStrip />


### PR DESCRIPTION
## Summary
- add tracked banner definitions with slot/camp metadata and StartRight fallbacks
- keep banner anchors base-safe in Pages builds and avoid exposing /go/ links
- wire updated banner placements on home, compare, and blog pages

## Testing
- npm run build
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ffd1bc3dc8326920a136c6dee410f)