### PR TITLE
[#28] Gear Kits V0 curated and compliant

### DIFF
--- a/WORK_QUEUE.md
+++ b/WORK_QUEUE.md
@@ -13,7 +13,7 @@
 ## Queue
 - [x] #26 Programs registry hardening + tests
 - [x] #27 Banners: data + safe placements
-- [ ] #28 Gear Kits V0 (curated, compliant)
+- [x] #28 Gear Kits V0 (curated, compliant)
 - [ ] #29 StartRight: choose V0 static wizard or fold into page
 - [ ] #30 Content fill: core pages
 - [ ] #31 Blog: publish 5 Phase-1 posts

--- a/src/data/gear-kits.ts
+++ b/src/data/gear-kits.ts
@@ -15,6 +15,8 @@ export type GearKit = {
   spotlight: string;
   items: GearItem[];
   conciergeNote?: string;
+  compliance: string[];
+  sourcing: string[];
 };
 
 export const gearKits: GearKit[] = [
@@ -54,7 +56,17 @@ export const gearKits: GearKit[] = [
       }
     ],
     conciergeNote:
-      'We calibrate this kit inside the StartRight walkthrough so you have a plug-and-play look on day one.'
+      'We calibrate this kit inside the StartRight walkthrough so you have a plug-and-play look on day one.',
+    compliance: [
+      'USB-powered gear only so you avoid uncertified power bricks and exposed wiring.',
+      'Visible webcam indicator light with no concealed recording hardware.',
+      'Indoor-rated lighting with diffusers to stay within common platform glare policies.'
+    ],
+    sourcing: [
+      'Ship from first-party or manufacturer stores to preserve warranty support.',
+      'Log serials for the webcam and mic in your StartRight dashboard for replacements.',
+      'If you travel, carry the mic and webcam in a padded pouch to avoid element damage.'
+    ]
   },
   {
     id: 'studio',
@@ -92,7 +104,17 @@ export const gearKits: GearKit[] = [
       }
     ],
     conciergeNote:
-      'During the StartRight concierge call we blueprint OBS scenes around this kit so your automation triggers stay on-brand.'
+      'During the StartRight concierge call we blueprint OBS scenes around this kit so your automation triggers stay on-brand.',
+    compliance: [
+      'HDMI capture is single-cable only—no wireless senders that could conflict with venue policies.',
+      'Mirrorless body is configured for clean HDMI with tally light active while streaming.',
+      'Audio interface gain staging keeps headroom for platform-level compressors.'
+    ],
+    sourcing: [
+      'Preference for used-but-rated camera bodies from trusted resellers with return windows.',
+      'Capture cards should ship with intact tamper seals; we log proof photos during intake.',
+      'Softboxes ship with UL-listed plugs and spare fuses inside the case for quick swap-outs.'
+    ]
   },
   {
     id: 'luxe',
@@ -130,6 +152,16 @@ export const gearKits: GearKit[] = [
       }
     ],
     conciergeNote:
-      'Our concierge engineers integrate this layout with your retention funnels and backstage dashboards.'
+      'Our concierge engineers integrate this layout with your retention funnels and backstage dashboards.',
+    compliance: [
+      'Dual-camera setup uses fixed, visible bodies—no hidden secondary capture angles.',
+      'Balanced lighting scenes avoid strobing or excessive blue light flagged by moderation teams.',
+      'Wireless lavs are set to clear, region-approved frequencies and labelled per performer.'
+    ],
+    sourcing: [
+      'GH5 bodies and Sigma lenses are paired with proof-of-service docs before deployment.',
+      'We add surge-protected power strips rated for the total load of the lighting grid.',
+      'Rodecaster profiles and Stream Deck macros ship preloaded to your StartRight account for auditability.'
+    ]
   }
 ];

--- a/src/pages/gear-kits.astro
+++ b/src/pages/gear-kits.astro
@@ -6,7 +6,7 @@ import { PRIMARY_CTA, KIT } from '../data/copy';
 import { gearKits } from '../data/gear-kits';
 
 const heroDescription =
-  'Pick the hardware stack that matches your room, budget, and concierge goals. These kits are field-tested inside StartRight so you launch with reliable lighting, clean audio, and an intentional backdrop.';
+  'Pick the hardware stack that matches your room, budget, and concierge goals. These kits are field-tested inside StartRight so you launch with reliable lighting, clean audio, and an intentional backdrop—without violating platform device policies.';
 
 const targetDate = new Date('2025-12-31T00:00:00Z');
 const now = new Date();
@@ -21,6 +21,13 @@ const countdown = {
 };
 
 const cohort = { current: 12, total: 28 };
+
+const complianceChecklist = [
+  'Every camera has a visible tally light or LED indicator—no covert capture.',
+  'Cabling plans avoid trip hazards and keep power within surge-protected limits.',
+  'We redact PII from placement photos before storing them in your StartRight binder.',
+  'Accessories are non-invasive (no permanent mounting) so rentals and sublets stay damage-free.'
+];
 ---
 
 <MainLayout
@@ -121,6 +128,28 @@ const cohort = { current: 12, total: 28 };
                 ))}
               </ul>
             </div>
+            <div class="space-y-3 text-sm text-white/70">
+              <p class="text-xs uppercase tracking-[0.35em] text-rose-petal/70">Compliance guardrails</p>
+              <ul class="space-y-2">
+                {kit.compliance.map((note) => (
+                  <li class="flex items-start gap-2">
+                    <span aria-hidden="true" class="mt-1 h-1.5 w-1.5 rounded-full bg-rose-gold"></span>
+                    <span>{note}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div class="space-y-3 text-sm text-white/70">
+              <p class="text-xs uppercase tracking-[0.35em] text-rose-petal/70">Concierge sourcing</p>
+              <ul class="space-y-2">
+                {kit.sourcing.map((note) => (
+                  <li class="flex items-start gap-2">
+                    <span aria-hidden="true" class="mt-1 h-1.5 w-1.5 rounded-full bg-rose-gold"></span>
+                    <span>{note}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
             {kit.conciergeNote && (
               <p class="mt-auto rounded-2xl border border-rose-gold/50 bg-rose-gold/10 p-4 text-xs text-rose-gold/80">
                 {kit.conciergeNote}
@@ -129,6 +158,23 @@ const cohort = { current: 12, total: 28 };
           </article>
         ))}
       </div>
+    </section>
+
+    <section class="content-card space-y-4 text-sm text-white/70">
+      <h2 class="section-heading">Compliance-first builds</h2>
+      <p>
+        Every kit ships with a documented setup so you can prove devices are visible, grounded, and within platform lighting
+        guidelines. Use these checkpoints with mods or venue managers before you go live.
+      </p>
+      <ul class="list-disc space-y-2 pl-5">
+        {complianceChecklist.map((note) => (
+          <li>{note}</li>
+        ))}
+      </ul>
+      <p>
+        Need an audit trail? Concierge logs serial numbers, wiring photos, and signed-off safety notes in your StartRight binder
+        so you can send proof to platforms or landlords without scrambling.
+      </p>
     </section>
 
     <section class="content-card space-y-4 text-sm text-white/70">


### PR DESCRIPTION
## Summary
- add compliance and sourcing guardrails to gear kit data for each package
- expand the gear kits page with compliance-first messaging and concierge sourcing details
- document queue progress by marking issue #28 complete

## Testing
- npm ci
- npm run build
- npm run build:pages
- grep -R "/go/" dist | head

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fff3c3da0832691018b58c31c8884)