### PR TITLE
[#31] Publish Phase-1 blog posts

### DIFF
--- a/WORK_QUEUE.md
+++ b/WORK_QUEUE.md
@@ -16,7 +16,7 @@
 - [x] #28 Gear Kits V0 (curated, compliant)
 - [x] #29 StartRight: choose V0 static wizard or fold into page
 - [x] #30 Content fill: core pages
-- [ ] #31 Blog: publish 5 Phase-1 posts
+- [x] #31 Blog: publish 5 Phase-1 posts
 - [ ] #32 SEO & sitemap/robots + OG/Twitter
 - [ ] #33 Analytics (env-gated)
 - [ ] #34 CI: pin Node 20.17 + build + /go/ guardrail

--- a/src/content/blog/dm-cadence-for-first-10-vips.md
+++ b/src/content/blog/dm-cadence-for-first-10-vips.md
@@ -1,0 +1,31 @@
+---
+title: 'DM Cadence for Your First 10 VIPs'
+description: 'A concierge-tested messaging schedule that converts your earliest fans into reliable tippers without burning out your inbox.'
+excerpt: 'Use this three-week DM cadence to identify and nurture the ten people most likely to become your first VIP tier.'
+publishDate: 2024-10-10
+category: 'VIP Pipeline'
+author: 'Elena, Head of Growth'
+heroImage: 'https://images.unsplash.com/photo-1517248143341-cc6191cef81c?auto=format&fit=crop&w=1600&q=80'
+heroImageAlt: 'Performer sending messages from a phone with studio lights in the background'
+cardImage: 'https://images.unsplash.com/photo-1517245386807-bb43f82c33c4?auto=format&fit=crop&w=1200&q=80'
+---
+
+## Week 1: Identify your candidates
+
+Run two short streams focused on conversation instead of shows. Track who chats, tips, and responds to your polls. After each stream, send a warm thank-you DM with a single question about what they want to see next week. The goal is to spot the ten names that consistently reply.
+
+## Week 2: Guided offers
+
+Split your candidates into two groups: live-room regulars and DM-heavy fans. Send live regulars a custom clip teaser and invite them to your next themed stream with a "VIP row" seat. For DM fans, send a concierge-style note with a private menu of two upsells and ask which one feels best for them.
+
+## Week 3: Close and onboard
+
+Pick the five warmest leads from each group. Offer them a simple VIP bundle: reserved shoutouts, first access to new shows, and a monthly DM check-in. Share a single checkout link from your StartRight kit and remind them the bundle is capped to ten people so they feel the scarcity.
+
+## Hygiene rules
+
+Never send more than three DMs to the same fan in a 72-hour window. Keep every message personalised—reference their last interaction so the cadence feels bespoke. When someone declines, move them back into the general audience and thank them genuinely so you can re-approach later.
+
+## Concierge checkpoints
+
+Log DM responses in your StartRight tracker and tag which offer resonated. In your weekly concierge call, review the tag data to adjust your scripts. Over time you will learn which phrases and timing windows convert best, and we will update your templates accordingly.

--- a/src/content/blog/lighting-setups-small-room.md
+++ b/src/content/blog/lighting-setups-small-room.md
@@ -1,0 +1,31 @@
+---
+title: 'Lighting Setups for Small Rooms'
+description: 'Turn tight spaces into flattering studios with three concierge-approved lighting patterns.'
+excerpt: 'Copy these three micro-studio lighting setups to keep your skin tone clean and your background luxe even in a cramped room.'
+publishDate: 2024-10-11
+category: 'Production Craft'
+author: 'Marco, Studio Lead'
+heroImage: 'https://images.unsplash.com/photo-1522199710521-72d69614c702?auto=format&fit=crop&w=1600&q=80'
+heroImageAlt: 'Ring light and softbox equipment in a compact room'
+cardImage: 'https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=1200&q=80'
+---
+
+## Setup 1: Ring + bounce
+
+Place your ring light just above eye level and angle it downward five degrees to avoid flat light. Bounce a desk lamp off a white wall to fill shadows. This combo keeps your eyes bright while preserving cheekbone contrast on camera.
+
+## Setup 2: Softbox + accent
+
+If you have one softbox, set it at a 45-degree angle and slightly above your face. Add a smart bulb behind you with a warm colour preset. The accent light separates you from the background and works well for moody evening shows.
+
+## Setup 3: Practical only
+
+When you cannot use stands, lean on practical lights. Two matching table lamps placed behind your camera create a soft wash. Tilt your laptop screen for an extra glow and drop your webcam exposure to prevent blown highlights.
+
+## Colour balance tips
+
+Lock your white balance to 4200–4500K and stick to it. Avoid mixing daylight from a window with warm bulbs; pick one and close the other source. A consistent balance keeps your skin tone trustworthy and reduces post-processing work.
+
+## Concierge checklist
+
+Take a quick still frame of each setup and send it to concierge for review. We will mark hotspots, recommend diffuser strength, and store the winning layout in your StartRight notes so you can rebuild it in minutes before a stream.

--- a/src/content/blog/moderator-playbook-new-rooms.md
+++ b/src/content/blog/moderator-playbook-new-rooms.md
@@ -1,0 +1,31 @@
+---
+title: 'Moderator Playbook for New Rooms'
+description: 'Train a two-person mod team to keep your vibe luxe, manage tip pacing, and protect your boundaries from day one.'
+excerpt: 'Hand your mods this playbook so they can greet guests, push the right tips at the right time, and keep your room safe.'
+publishDate: 2024-10-14
+category: 'Community Ops'
+author: 'Raya, Concierge Lead'
+heroImage: 'https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=1600&q=80'
+heroImageAlt: 'Moderator control desk with laptop and notes'
+cardImage: 'https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=1200&q=80'
+---
+
+## Pre-show brief
+
+Share the night’s script, the active tip ladder, and the one boundary you want enforced hardest. Mods pin the tip menu and update the pinned message whenever a Tier 2 or Tier 3 item sells out.
+
+## First 15 minutes
+
+Mods welcome each returning viewer by name and remind newcomers about the vibe of the night. They should drop a light CTA every five minutes that points to your Tier 1 items so momentum builds without pressure.
+
+## Mid-show pacing
+
+When chat slows, mods run a poll with two options from your Tier 2 ladder and set a five-minute timer. They should also highlight any VIP bundle slots left to create urgency. If a viewer is disruptive, mods use a warning script first, then mute.
+
+## Closing rituals
+
+Ten minutes before you end, a mod posts the remaining VIP slots and the schedule for your next stream. They also capture usernames of anyone who tipped twice so you can send Saturday gratitude DMs.
+
+## Aftercare and review
+
+Mods log notable moments in your StartRight tracker: jokes that landed, offers that flopped, and any boundary violations. In the weekly concierge debrief, you’ll use these notes to adjust scripts and update the mod checklist.

--- a/src/content/blog/tip-menu-architecture.md
+++ b/src/content/blog/tip-menu-architecture.md
@@ -1,0 +1,31 @@
+---
+title: 'Tip Menu Architecture That Sells'
+description: 'Structure your tip ladder so casual viewers always see a next step and VIPs have premium anchors to climb toward.'
+excerpt: 'Build a three-tier tip menu that protects your energy, raises average order value, and still feels generous to new fans.'
+publishDate: 2024-10-12
+category: 'Monetization'
+author: 'Lina, Data Strategist'
+heroImage: 'https://images.unsplash.com/photo-1515165562835-c4c5677f0c83?auto=format&fit=crop&w=1600&q=80'
+heroImageAlt: 'Performer writing a tip ladder on a notepad'
+cardImage: 'https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=1200&q=80'
+---
+
+## Tier 1: Daily movers
+
+These are low-effort, repeatable actions priced between $5–$15. Think quick shoutouts, name-in-lights overlays, or a single emote request. They train casual viewers to transact and create momentum early in a show.
+
+## Tier 2: Signature moments
+
+Anchor this tier around $25–$60 with items that take focus for two to three minutes: a short routine, a camera angle swap, or a custom affirmation in your voice. Keep three options max so the room can rally behind a clear goal.
+
+## Tier 3: VIP anchors
+
+Reserve this tier for $100+ and cap it to two slots per show. Offer a private five-minute debrief after the stream or a bespoke clip delivered within 72 hours. Scarcity keeps the value high and prevents burnout.
+
+## Pricing hygiene
+
+Price endings at clean numbers—$15, $45, $120—so tips are easy to remember. Test one variable at a time each week and log the conversion in your StartRight tracker. Avoid underpricing your energy-intensive moments; they should live in Tier 3.
+
+## Menu presentation
+
+Display the ladder in your overlay and pin it in chat every 30 minutes. Before you end a show, restate which Tier 2 and Tier 3 slots remain so last-minute VIPs have a clear path to buy.

--- a/src/content/blog/weekly-stream-schedule.md
+++ b/src/content/blog/weekly-stream-schedule.md
@@ -1,0 +1,35 @@
+---
+title: 'Weekly Stream Schedule Blueprint'
+description: 'A seven-day cadence that balances growth, rest, and revenue, tuned for new models using the StartRight kit.'
+excerpt: 'Follow this weekly schedule template to keep your room active without burning out while you climb to your first $2,000 month.'
+publishDate: 2024-10-13
+category: 'Operations'
+author: 'Raya, Concierge Lead'
+heroImage: 'https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=1600&q=80'
+heroImageAlt: 'Calendar planner with sticky notes and coffee on a desk'
+cardImage: 'https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=1200&q=80'
+---
+
+## Monday: Reset and plan
+
+No streaming today. Review last week’s performance with concierge, adjust your tip ladder, and queue new banners or overlays. Post a teaser clip to your socials to set expectations for the week.
+
+## Tuesday: Soft open (60–90 minutes)
+
+Host a shorter stream to test updated prompts and lighting. Keep your tip ladder simple and invite returning viewers to Wednesday’s feature show. Capture who reacts to the new menu for follow-up DMs.
+
+## Wednesday: Feature show (2 hours)
+
+This is your main revenue driver. Run your signature script, spotlight the Week’s VIP bundle, and track conversions live. End with a clear CTA for Friday’s interactive stream.
+
+## Friday: Interactive night (90 minutes)
+
+Use polls, trivia, or a mini-game to involve chat. Offer limited-time Tier 2 items to keep pace high. Log every participant so you can send gratitude DMs on Saturday.
+
+## Saturday: DM day (30–45 minutes)
+
+No live stream. Send personalised recaps and teasers for Sunday. Offer a small thank-you clip to anyone who tipped twice this week. This keeps the pipeline warm without draining your voice.
+
+## Sunday: Brunch stream (75 minutes)
+
+Light, conversational, and earlier in the day to catch new time zones. Promote next week’s schedule and remind viewers how to join your VIP bundle. This closes the loop before Monday’s reset.


### PR DESCRIPTION
## Summary
- add five new Phase-1 concierge blog posts covering VIP outreach, lighting, tip menus, scheduling, and mod playbooks
- mark work queue item #31 as complete

## Testing
- npm ci
- npm run build
- npm run build:pages
- rg -l "/go/" dist | head

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69200a15b2f483269593159f4ed8509e)