### PR TITLE
chore: tighten SEO metadata and robots

### DIFF
--- a/WORK_QUEUE.md
+++ b/WORK_QUEUE.md
@@ -17,6 +17,6 @@
 - [x] #29 StartRight: choose V0 static wizard or fold into page
 - [x] #30 Content fill: core pages
 - [x] #31 Blog: publish 5 Phase-1 posts
-- [ ] #32 SEO & sitemap/robots + OG/Twitter
+- [x] #32 SEO & sitemap/robots + OG/Twitter
 - [ ] #33 Analytics (env-gated)
 - [ ] #34 CI: pin Node 20.17 + build + /go/ guardrail

--- a/public/og/naughtycamspot-default.svg
+++ b/public/og/naughtycamspot-default.svg
@@ -1,0 +1,27 @@
+<svg width="1200" height="630" viewBox="0 0 1200 630" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0b0f1c" />
+      <stop offset="50%" stop-color="#1a0f1f" />
+      <stop offset="100%" stop-color="#0b111c" />
+    </linearGradient>
+    <linearGradient id="glow" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#F4C4D4" stop-opacity="0.95" />
+      <stop offset="100%" stop-color="#D9967E" stop-opacity="0.75" />
+    </linearGradient>
+    <filter id="blur" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="80" />
+    </filter>
+  </defs>
+  <rect width="1200" height="630" rx="36" fill="url(#bg)" />
+  <circle cx="260" cy="170" r="180" fill="#F4C4D4" fill-opacity="0.15" filter="url(#blur)" />
+  <circle cx="980" cy="130" r="140" fill="#F4C4D4" fill-opacity="0.12" filter="url(#blur)" />
+  <circle cx="1020" cy="470" r="190" fill="#D9967E" fill-opacity="0.12" filter="url(#blur)" />
+  <rect x="80" y="110" width="1040" height="410" rx="32" stroke="#F4C4D4" stroke-opacity="0.35" stroke-width="2" />
+  <rect x="110" y="140" width="980" height="350" rx="28" fill="rgba(255,255,255,0.04)" stroke="#F4C4D4" stroke-opacity="0.18" stroke-width="1.5" />
+  <text x="150" y="250" fill="url(#glow)" font-family="'Playfair Display', 'Georgia', serif" font-size="72" font-weight="700">NaughtyCamSpot</text>
+  <text x="150" y="320" fill="#E7D7DC" fill-opacity="0.85" font-family="'Inter', 'Helvetica Neue', Arial, sans-serif" font-size="30" font-weight="500" letter-spacing="3">LUXURY CAM MODEL CONCIERGE</text>
+  <text x="150" y="380" fill="#F3E7EA" fill-opacity="0.85" font-family="'Inter', 'Helvetica Neue', Arial, sans-serif" font-size="20" font-weight="400" letter-spacing="1.6">
+    StartRight rituals, guarded tracking, and rose-gold aesthetics for ambitious performers.
+  </text>
+</svg>

--- a/public/robots.pages.txt
+++ b/public/robots.pages.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/public/robots.prod.txt
+++ b/public/robots.prod.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://naughtycamspot.com/sitemap-index.xml

--- a/src/components/SEO.astro
+++ b/src/components/SEO.astro
@@ -9,7 +9,19 @@ const {
 
 const site = import.meta.env.SITE ?? '';
 const canonicalUrl = site ? new URL(path, site).toString() : path;
-const twitterCard = ogImage ? 'summary_large_image' : 'summary';
+const defaultOgImage = new URL('/og/naughtycamspot-default.svg', site || 'https://naughtycamspot.com').toString();
+const resolvedOgImage = (() => {
+  if (!ogImage) {
+    return defaultOgImage;
+  }
+
+  if (site && !/^https?:\/\//i.test(ogImage)) {
+    return new URL(ogImage, site).toString();
+  }
+
+  return ogImage;
+})();
+const twitterCard = resolvedOgImage ? 'summary_large_image' : 'summary';
 ---
 <title>{title}</title>
 <meta name="description" content={description} />
@@ -18,8 +30,8 @@ const twitterCard = ogImage ? 'summary_large_image' : 'summary';
 <meta property="og:description" content={description} />
 <meta property="og:type" content={ogType} />
 <meta property="og:url" content={canonicalUrl} />
-{ogImage && <meta property="og:image" content={ogImage} />}
+{resolvedOgImage && <meta property="og:image" content={resolvedOgImage} />}
 <meta name="twitter:card" content={twitterCard} />
 <meta name="twitter:title" content={title} />
 <meta name="twitter:description" content={description} />
-{ogImage && <meta name="twitter:image" content={ogImage} />}
+{resolvedOgImage && <meta name="twitter:image" content={resolvedOgImage} />}

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -1,5 +1,6 @@
 ---
 import { getCollection } from 'astro:content';
+import SEO from '../components/SEO.astro';
 import MainLayout from '../layouts/MainLayout.astro';
 import { withBase } from '../utils/links';
 
@@ -35,6 +36,7 @@ for (const key of trackingKeys) {
 }
 
 const trackingQuery = trackingParams.toString();
+const canonicalPath = '/blog';
 const buildPostHref = (slug: string) => {
   const baseHref = withBase(`/blog/${slug}`);
   if (!trackingQuery) {
@@ -53,6 +55,12 @@ const totalPosts = posts.length;
   title="Blog | NaughtyCamSpot"
   description="Insights & stories from the NaughtyCamSpot concierge team — luxury growth strategy for performers."
 >
+  <SEO
+    slot="head"
+    title="Blog | NaughtyCamSpot"
+    description="Field notes, launch frameworks, and concierge debriefs from the NaughtyCamSpot team."
+    path={canonicalPath}
+  />
   <!-- SECTION: Blog Hero -->
   <section class="hero-shell parallax-veil">
     <div class="pointer-events-none absolute inset-0 bg-gradient-to-r from-black/50 via-transparent to-black/60"></div>

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -2,6 +2,7 @@
 import { getCollection } from 'astro:content';
 import BannerSlot from '../../components/BannerSlot.astro';
 import LinkCTA from '../../components/LinkCTA.astro';
+import SEO from '../../components/SEO.astro';
 import MainLayout from '../../layouts/MainLayout.astro';
 import { PRIMARY_CTA } from '../../data/copy';
 import { formatDateStamp, withBase } from '../../utils/links';
@@ -34,6 +35,9 @@ const firstParagraph =
     .map((block) => block.trim())
     .find((block) => block && !block.startsWith('#')) ?? post.data.description ?? '';
 
+const metaDescription = post.data.description ?? firstParagraph;
+const canonicalPath = `/blog/${post.slug}`;
+const ogImage = post.data.cardImage ?? post.data.heroImage;
 const isPages = import.meta.env.IS_PAGES === 'true';
 const trackingQuery = new URLSearchParams({
   src: `blog_${post.slug}`,
@@ -64,6 +68,14 @@ const startRightMessage = isPages
   title={`${post.data.title} | NaughtyCamSpot Journal`}
   description={post.data.description}
 >
+  <SEO
+    slot="head"
+    title={`${post.data.title} | NaughtyCamSpot Journal`}
+    description={metaDescription}
+    path={canonicalPath}
+    ogImage={ogImage}
+    ogType="article"
+  />
   <!-- SECTION: Hero -->
   <article class="space-y-10">
     <header class="hero-shell parallax-veil">

--- a/src/pages/compare.astro
+++ b/src/pages/compare.astro
@@ -2,6 +2,7 @@
 import BannerSlot from '../components/BannerSlot.astro';
 import LinkCTA from '../components/LinkCTA.astro';
 import Notices from '../components/Notices.astro';
+import SEO from '../components/SEO.astro';
 import MainLayout from '../layouts/MainLayout.astro';
 import Hero from '../partials/home/Hero.astro';
 import { PRIMARY_CTA } from '../data/copy';
@@ -33,6 +34,7 @@ type ProgramCard = Program & {
 };
 
 const dateStamp = formatDateStamp();
+const canonicalPath = '/compare';
 const enrichedPrograms: Program[] = (programs as ProgramEntry[]).map((program) => ({
   ...program,
   ...resolveProgramDetail(program.key)
@@ -71,6 +73,12 @@ const programCards: ProgramCard[] = enrichedPrograms
 ---
 
 <MainLayout title="Compare cam platforms" description="Compare cam platforms tailored for new creators launching with NaughtyCamSpot.">
+  <SEO
+    slot="head"
+    title="Cam program compare | NaughtyCamSpot"
+    description="Review concierge-approved cam program readiness, geo allowances, and guarded join paths in one table."
+    path={canonicalPath}
+  />
   <Hero />
   <section class="space-y-8">
     <Notices />

--- a/src/pages/disclosure.astro
+++ b/src/pages/disclosure.astro
@@ -1,11 +1,20 @@
 ---
+import SEO from '../components/SEO.astro';
 import MainLayout from '../layouts/MainLayout.astro';
+
+const canonicalPath = '/disclosure';
 ---
 
 <MainLayout
   title="Affiliate Disclosure | NaughtyCamSpot"
   description="Affiliate disclosure for NaughtyCamSpot model recruitment and outbound links."
 >
+  <SEO
+    slot="head"
+    title="Affiliate disclosure | NaughtyCamSpot"
+    description="How NaughtyCamSpot uses affiliate links to fund the StartRight kit for approved model signups."
+    path={canonicalPath}
+  />
   <section class="content-card space-y-4 text-sm text-white/70">
     <h1 class="section-heading">Affiliate Disclosure</h1>
     <p>

--- a/src/pages/earnings.astro
+++ b/src/pages/earnings.astro
@@ -1,6 +1,7 @@
 ---
 import LinkCTA from '../components/LinkCTA.astro';
 import Notices from '../components/Notices.astro';
+import SEO from '../components/SEO.astro';
 import MainLayout from '../layouts/MainLayout.astro';
 import { PRIMARY_CTA } from '../data/copy';
 import { formatDateStamp } from '../utils/links';
@@ -27,6 +28,7 @@ const bandLabels: Record<string, string> = {
   top10: 'Top 10%'
 };
 
+const canonicalPath = '/earnings';
 const cards = bandEntries.map(([key, bands]) => {
   const program = programIndex.get(key);
   const slot = `earnings_${key}`;
@@ -54,6 +56,12 @@ const cards = bandEntries.map(([key, bands]) => {
 ---
 
 <MainLayout title="Earnings benchmarks" description="Understand weekly earnings ranges for NaughtyCamSpot partner platforms.">
+  <SEO
+    slot="head"
+    title="Earnings benchmarks | NaughtyCamSpot"
+    description="Illustrative weekly ranges by platform so you can calibrate StartRight focus areas and guarded join links."
+    path={canonicalPath}
+  />
   <section class="space-y-8">
     <Notices />
     <div class="space-y-4">

--- a/src/pages/gear-kits.astro
+++ b/src/pages/gear-kits.astro
@@ -1,6 +1,7 @@
 ---
 import LinkCTA from '../components/LinkCTA.astro';
 import Notices from '../components/Notices.astro';
+import SEO from '../components/SEO.astro';
 import MainLayout from '../layouts/MainLayout.astro';
 import { PRIMARY_CTA, KIT } from '../data/copy';
 import { gearKits } from '../data/gear-kits';
@@ -28,12 +29,20 @@ const complianceChecklist = [
   'We redact PII from placement photos before storing them in your StartRight binder.',
   'Accessories are non-invasive (no permanent mounting) so rentals and sublets stay damage-free.'
 ];
+
+const canonicalPath = '/gear-kits';
 ---
 
 <MainLayout
   title="Gear kits for cam creators"
   description="Curated StartRight gear kits for performers upgrading their cam studio."
 >
+  <SEO
+    slot="head"
+    title="Gear kits for cam creators | NaughtyCamSpot"
+    description="Curated StartRight gear kits with concierge calibration, compliance guardrails, and tracked intake links."
+    path={canonicalPath}
+  />
   <section class="space-y-8">
     <Notices />
     <div class="rounded-[28px] border border-rose-gold/40 bg-rose-gold/10 p-6 backdrop-blur-xl sm:p-7">

--- a/src/pages/join-models.astro
+++ b/src/pages/join-models.astro
@@ -1,6 +1,7 @@
 ---
 import LinkCTA from '../components/LinkCTA.astro';
 import Notices from '../components/Notices.astro';
+import SEO from '../components/SEO.astro';
 import MainLayout from '../layouts/MainLayout.astro';
 import { buildTrackedLink } from '../utils/links';
 
@@ -22,6 +23,12 @@ const pagesJoinHref = '/startright';
   title="Join models | NaughtyCamSpot"
   description="Route your signups through guarded links so concierge can unlock your StartRight kit."
 >
+  <SEO
+    slot="head"
+    title="Join models with concierge | NaughtyCamSpot"
+    description="Use guarded join links so concierge can verify your signup, unlock the StartRight kit, and keep tracking clean."
+    path={canonicalPath}
+  />
   <section class="space-y-10">
     <Notices />
     <div class="space-y-4">

--- a/src/pages/models/[slug].astro
+++ b/src/pages/models/[slug].astro
@@ -1,6 +1,7 @@
 ---
 import LinkCTA from '../../components/LinkCTA.astro';
 import Notices from '../../components/Notices.astro';
+import SEO from '../../components/SEO.astro';
 import MainLayout from '../../layouts/MainLayout.astro';
 import { getCollection, type CollectionEntry } from 'astro:content';
 import { buildTrackedLink } from '../../utils/links';
@@ -21,6 +22,7 @@ const data = model.data;
 const slug = model.slug ?? model.id;
 const canonicalPath = `/models/${slug}`;
 const canonicalUrl = `https://naughtycamspot.com${canonicalPath}`;
+const ogImage = data.cardImage ?? data.heroImage;
 
 const buttonOrder = ['manyvids', 'beacons', 'stripchat', 'chaturbate', 'camsoda', 'pornhub', 'onlyfans', 'myclub'];
 const orderedPlatforms = [
@@ -63,6 +65,14 @@ const jsonLd = {
 ---
 
 <MainLayout title={`${data.name} | NaughtyCamSpot`} description={data.summary}>
+  <SEO
+    slot="head"
+    title={`${data.name} | NaughtyCamSpot`}
+    description={data.summary}
+    path={canonicalPath}
+    ogImage={ogImage}
+    ogType="profile"
+  />
   <section class="space-y-10">
     <Notices />
     <div class="grid gap-10 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)] lg:items-start">

--- a/src/pages/models/index.astro
+++ b/src/pages/models/index.astro
@@ -1,6 +1,7 @@
 ---
 import LinkCTA from '../../components/LinkCTA.astro';
 import Notices from '../../components/Notices.astro';
+import SEO from '../../components/SEO.astro';
 import MainLayout from '../../layouts/MainLayout.astro';
 import { getCollection, type CollectionEntry } from 'astro:content';
 import { withBase } from '../../utils/links';
@@ -23,9 +24,16 @@ const rangeLabels: Record<string, string> = {
   top25: 'Top 25%',
   top10: 'Top 10%'
 };
+const canonicalPath = '/models';
 ---
 
 <MainLayout title="Model walkthroughs" description="Example model walkthroughs and concierge launch playbooks.">
+  <SEO
+    slot="head"
+    title="Model walkthroughs | NaughtyCamSpot"
+    description="Concierge-managed model walkthroughs with archetypes, guarded join paths, and StartRight notes."
+    path={canonicalPath}
+  />
   <section class="space-y-10">
     <Notices />
     <div class="space-y-3">

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -1,5 +1,8 @@
 ---
+import SEO from '../components/SEO.astro';
 import MainLayout from '../layouts/MainLayout.astro';
+
+const canonicalPath = '/privacy';
 ---
 
 <MainLayout
@@ -7,6 +10,12 @@ import MainLayout from '../layouts/MainLayout.astro';
   description="Privacy policy and data handling practices for NaughtyCamSpot."
   showNavigation={false}
 >
+  <SEO
+    slot="head"
+    title="Privacy policy | NaughtyCamSpot"
+    description="How NaughtyCamSpot handles intake forms, analytics, and StartRight concierge data across every surface."
+    path={canonicalPath}
+  />
   <section class="hero-shell parallax-veil">
     <div class="pointer-events-none absolute inset-0 bg-gradient-to-br from-black/60 via-transparent to-black/70"></div>
     <div class="relative space-y-4">

--- a/src/pages/terms.astro
+++ b/src/pages/terms.astro
@@ -1,5 +1,8 @@
 ---
+import SEO from '../components/SEO.astro';
 import MainLayout from '../layouts/MainLayout.astro';
+
+const canonicalPath = '/terms';
 ---
 
 <MainLayout
@@ -7,6 +10,12 @@ import MainLayout from '../layouts/MainLayout.astro';
   description="Terms and service conditions for NaughtyCamSpot."
   showNavigation={false}
 >
+  <SEO
+    slot="head"
+    title="Terms & conditions | NaughtyCamSpot"
+    description="Terms governing NaughtyCamSpot concierge services, tracked links, and resource access."
+    path={canonicalPath}
+  />
   <section class="hero-shell parallax-veil">
     <div class="pointer-events-none absolute inset-0 bg-gradient-to-bl from-black/60 via-transparent to-black/70"></div>
     <div class="relative space-y-4">


### PR DESCRIPTION
## Summary
- add default Open Graph image fallback and wire SEO metadata across blog, model, and static pages
- publish environment-specific robots directives and keep sitemap references aligned
- ensure canonical URLs and OG/Twitter cards render consistently for dynamic content

## Testing
- npm ci || npm install
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69200b8a2714832697a2e4a8489a357b)