### PR TITLE
Env-gate analytics tracking (Closes #33)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,9 @@ branch has diverged, the script will warn so you can handle the merge manually.
 
 ## Analytics & click beacons
 
+- Enable analytics explicitly by setting `PUBLIC_ENABLE_ANALYTICS=true` in the environment; when unset or false, the site skips both GA and beacon scripts.
 - Set the GA4 measurement ID through the `PUBLIC_GA4_ID` environment variable (for example, add `PUBLIC_GA4_ID=G-XXXXXXX` to your ViceTemple `.env`).
-- The GA snippet only renders when `import.meta.env.SITE` resolves to `https://naughtycamspot.com` **and** `IS_PAGES` is not flagged, so GitHub Pages previews never emit tracking.
+- The GA snippet only renders when analytics are enabled, `import.meta.env.SITE` resolves to `https://naughtycamspot.com`, **and** `IS_PAGES` is not flagged, so GitHub Pages previews never emit tracking.
 - Click beacons fire for any element marked with `data-track="click"` (homepage hero CTA and all banner slots in production) and send lightweight GET requests to `/go/click.php` with the slot, campaign, and timestamp.
 - ViceTemple writes those beacon hits to `logs/clicks.log` (see `public/go/click.php`). Pages builds keep the PHP handler inert because the environment never executes the file.
 

--- a/WORK_QUEUE.md
+++ b/WORK_QUEUE.md
@@ -18,5 +18,5 @@
 - [x] #30 Content fill: core pages
 - [x] #31 Blog: publish 5 Phase-1 posts
 - [x] #32 SEO & sitemap/robots + OG/Twitter
-- [ ] #33 Analytics (env-gated)
+- [x] #33 Analytics (env-gated)
 - [ ] #34 CI: pin Node 20.17 + build + /go/ guardrail

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -26,9 +26,13 @@ const resolveHostname = (value) => {
   }
 };
 
+const analyticsEnvFlag =
+  typeof import.meta.env.PUBLIC_ENABLE_ANALYTICS === 'string'
+    ? import.meta.env.PUBLIC_ENABLE_ANALYTICS.trim().toLowerCase() === 'true'
+    : false;
 const siteHostname = resolveHostname(import.meta.env.SITE ?? '');
 const isProdSite = siteHostname === 'naughtycamspot.com';
-const shouldTrackClicks = isProdSite && !isPagesBuild;
+const shouldTrackClicks = analyticsEnvFlag && isProdSite && !isPagesBuild;
 const gaMeasurementId =
   typeof import.meta.env.PUBLIC_GA4_ID === 'string'
     ? import.meta.env.PUBLIC_GA4_ID.trim()


### PR DESCRIPTION
## Summary
- gate Google Analytics and click beacons behind a PUBLIC_ENABLE_ANALYTICS flag in the main layout
- update README analytics section with the new environment toggle and gating description
- keep the work queue up to date for issue #33

## Testing
- npm run build
- npm run build:pages
- rg "/go/" dist


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69200dcd7694832689d3bab5cd4081cb)