### PR TITLE
[#34] Add CI workflow with /go/ guardrail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI Build
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.17.0'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: |
+          npm ci || npm install
+
+      - name: Build Pages artifact
+        run: npm run build:pages
+
+      - name: Guardrail: block /go/ in build output
+        run: |
+          if grep -R "/go/" dist; then
+            echo "Build artifact must not emit /go/ paths"
+            exit 1
+          fi
+
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '20.17.0'
           cache: 'npm'
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 20.17.0
           cache: npm
       - name: Install deps
         run: npm ci

--- a/WORK_QUEUE.md
+++ b/WORK_QUEUE.md
@@ -19,4 +19,4 @@
 - [x] #31 Blog: publish 5 Phase-1 posts
 - [x] #32 SEO & sitemap/robots + OG/Twitter
 - [x] #33 Analytics (env-gated)
-- [ ] #34 CI: pin Node 20.17 + build + /go/ guardrail
+- [x] #34 CI: pin Node 20.17 + build + /go/ guardrail


### PR DESCRIPTION
## Summary
- add a CI workflow that pins Node 20.17.0, runs the Pages build, enforces the /go/ guardrail, and uploads artifacts
- align Pages workflows to use Node 20.17.0
- mark work queue item #34 as complete

## Testing
- npm ci
- npm run build
- npm run build:pages


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692010a13bcc8326921e0d2cbe761676)