### PR TITLE
Add homepage content updates

### DIFF
--- a/src/data/copy.ts
+++ b/src/data/copy.ts
@@ -1,12 +1,12 @@
 export const DISCLOSURE = "Contains affiliate links. Not an agency. No earnings guarantee.";
 
 export const HERO = {
-  title: 'StartRight for models',
-  sub: 'Skip the guesswork. Pick the right platforms and get a tailored launch kit — free.'
+  title: 'Start Smart. Cam Confidently.',
+  sub: 'Join one of the fastest ways to earn online — with expert-backed support from day one. NaughtyCamSpot is your VIP gateway to launching a successful cam career.'
 } as const;
 
 export const PRIMARY_CTA = {
-  label: 'Get my plan',
+  label: 'Sign Up Now – Get the Kit →',
   pagesHref: '/startright',
   prodHref: '/startright'
 } as const;

--- a/src/partials/home/Hero.astro
+++ b/src/partials/home/Hero.astro
@@ -16,7 +16,7 @@ const primaryCta = {
     <div class="grid gap-16 lg:grid-cols-[minmax(0,1fr)_minmax(0,0.85fr)] lg:items-center">
       <div class="space-y-7">
         <p class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-[clamp(0.7rem,1vw,0.85rem)] uppercase tracking-[0.4em] text-rose-petal/80">
-          Concierge referral collective
+          StartRight concierge
         </p>
         <h1 class="font-display text-[clamp(2.8rem,6vw,4.25rem)] leading-[1.05] text-white">
           {HERO.title}
@@ -25,8 +25,8 @@ const primaryCta = {
           {HERO.sub}
         </p>
         <p class="max-w-xl text-[clamp(0.95rem,2vw,1.1rem)] text-white/70">
-          Trade management promises for concierge guidance. We map the right platforms, script your launch rituals, and send the
-          StartRight kit once your proof lands.
+          Sign up through our trusted partners and unlock your StartRight Kit. We map the right platforms, script your launch
+          rituals, and deliver concierge-backed support from day one.
         </p>
         <LinkCTA
           class="inline-flex border border-rose-gold/70 bg-rose-gold px-6 py-3 text-lg text-midnight shadow-glow"

--- a/src/partials/home/HowItWorks.astro
+++ b/src/partials/home/HowItWorks.astro
@@ -3,22 +3,28 @@ import { withBase } from '../../utils/links';
 
 const steps = [
   {
-    title: 'Share proof of acceptance',
+    title: 'Pick a cam platform and sign up',
     description:
-      'Send your welcome email or dashboard screenshot. We use it to confirm payout routing and unlock the right kit modules.',
-    link: { href: '/startright', label: 'Unlock StartRight kit' }
+      'Choose a trusted partner platform and complete signup using our affiliate link so we can track your bonus and unlock your perks.',
+    link: { href: '/compare', label: 'Choose a platform' }
   },
   {
-    title: 'Pick your launch rituals',
+    title: 'Submit proof and get your StartRight Kit',
     description:
-      'Choose from scripted countdowns, lighting cues, and mod prompts. We tailor the onboarding run-of-show to your vibe.',
-    link: { href: '/gear-kits', label: 'Review gear kits' }
+      'Send quick proof of signup to unlock the StartRight Kit with curated guides, templates, and onboarding tips.',
+    link: { href: '/startright', label: 'Get the kit' }
   },
   {
-    title: 'Keep concierge on standby',
+    title: 'Access VIP tools and support',
     description:
-      'Check in after shows, adjust offers, and schedule retention pushes. No contracts—just a StartRight desk when you need it.',
-    link: { href: '/blog', label: 'Browse field notes' }
+      'Tap into concierge-backed resources, pacing prompts, and templates that help you run your room with confidence.',
+    link: { href: '/blog', label: 'Browse tools' }
+  },
+  {
+    title: 'Reach milestones and get featured',
+    description:
+      'Hit performance milestones to unlock spotlight opportunities and direct links to your room on our Featured Model pages.',
+    link: { href: '/startright', label: 'Start Earning – Join Now →' }
   }
 ] as const;
 ---
@@ -28,10 +34,10 @@ const steps = [
       <p class="mx-auto text-[clamp(0.75rem,1.2vw,0.9rem)] uppercase tracking-[0.4em] text-rose-petal/70">
         How it works
       </p>
-      <h2 class="font-display text-[clamp(2.1rem,5vw,3rem)] text-white">Three steps to your StartRight plan</h2>
+      <h2 class="font-display text-[clamp(2.1rem,5vw,3rem)] text-white">Four steps to launch with NCS</h2>
       <p class="mx-auto max-w-3xl text-[clamp(0.95rem,1.9vw,1.15rem)] text-white/70">
-        The kit is free after you route your signup through our links and send proof. We keep templates fresh so you can relaunch
-        with confidence whenever your strategy evolves.
+        Follow the StartRight path: choose a platform, send proof, unlock your kit, and keep concierge tools on standby while you
+        build momentum.
       </p>
     </div>
     <div class="mt-16 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">

--- a/src/partials/home/MiniTestimonials.astro
+++ b/src/partials/home/MiniTestimonials.astro
@@ -3,28 +3,12 @@ import { withBase } from '../../utils/links';
 
 const testimonials = [
   {
-    name: 'Evelyn Noir',
-    role: 'Full-time cam model',
+    name: 'Featured Model Spotlight',
+    role: 'Placeholder profile',
     quote:
-      'The StartRight kit gave me a full month of themed rooms. I finally feel like I am hosting experiences, not just logging on.',
+      'Meet real NCS models making real progress. Our Featured Model pages highlight top performers and link directly to their rooms.',
     image:
-      'https://images.unsplash.com/photo-1517840933437-c41356892b41?auto=format&fit=crop&w=240&q=80'
-  },
-  {
-    name: 'Nova Lynx',
-    role: 'Hybrid creator',
-    quote:
-      'Concierge check-ins keep me accountable. We iterate on offers every week so fans never feel the copy-paste fatigue.',
-    image:
-      'https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=240&q=80'
-  },
-  {
-    name: 'Aria Bloom',
-    role: 'Newly signed',
-    quote:
-      'Their platform breakdowns saved me from messy rev-shares. I knew exactly where to launch and how to protect my time.',
-    image:
-      'https://images.unsplash.com/photo-1544723795-3fb6469f5b39?auto=format&fit=crop&w=240&q=80'
+      'https://images.unsplash.com/photo-1517841905240-472988babdf9?auto=format&fit=crop&w=240&q=80'
   }
 ] as const;
 ---
@@ -32,14 +16,14 @@ const testimonials = [
   <div class="mx-auto max-w-6xl">
     <div class="flex flex-col gap-4 text-center">
       <p class="mx-auto text-[clamp(0.75rem,1.2vw,0.9rem)] uppercase tracking-[0.4em] text-rose-petal/70">
-        Community notes
+        Featured Model spotlight
       </p>
       <h2 class="font-display text-[clamp(2rem,4.5vw,2.9rem)] text-white">
-        Quick wins from the concierge desk
+        Meet the models leading the way
       </h2>
       <p class="mx-auto max-w-3xl text-[clamp(0.95rem,1.9vw,1.15rem)] text-white/70">
-        Borrow the scripts, lighting recipes, and schedule prompts our models rely on. Peek at the blog when you want deeper
-        playbooks.
+        Meet real NCS models making real progress. Spotlight features link directly to their rooms and showcase how StartRight
+        support translates into momentum.
       </p>
     </div>
     <div class="mt-14 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
@@ -58,8 +42,8 @@ const testimonials = [
             </figcaption>
           </div>
           <blockquote class="text-[clamp(0.95rem,1.7vw,1.1rem)] leading-relaxed text-white/80">“{testimonial.quote}”</blockquote>
-          <a class="mt-auto inline-flex text-[clamp(0.78rem,1.4vw,0.9rem)] uppercase tracking-[0.35em] text-rose-gold transition hover:text-white" href={withBase('/blog')}>
-            Read the latest playbooks
+          <a class="mt-auto inline-flex text-[clamp(0.78rem,1.4vw,0.9rem)] uppercase tracking-[0.35em] text-rose-gold transition hover:text-white" href={withBase('/startright')}>
+            Become a Featured Model →
           </a>
         </figure>
       ))}

--- a/src/partials/home/WhatYouGet.astro
+++ b/src/partials/home/WhatYouGet.astro
@@ -3,33 +3,40 @@ import { withBase } from '../../utils/links';
 
 const tiles = [
   {
-    title: 'Proof vault',
+    title: 'Fast-track sign-up with verified platforms',
     description:
-      'Snapshots from partner approvals, payout receipts, and concierge notes so you can see how the StartRight desk documents wins.',
-    link: { href: '/disclosure', label: 'Read disclosures' }
+      'Pick a trusted partner platform and onboard faster with concierge checklists that keep you moving without surprises.',
+    link: { href: '/compare', label: 'View partner platforms' }
   },
   {
-    title: 'Example builds',
+    title: 'Free StartRight Kit after signup',
     description:
-      'Reference bios, lighting setups, and storytelling beats we refine with creators before launch. Borrow layouts, keep your voice.',
-    link: { href: '/startright', label: 'Start my kit' }
+      'Unlock insider guides, content templates, and onboarding tips the moment you join through our links — the kit is on us.',
+    link: { href: '/startright', label: 'Claim your kit' }
   },
   {
-    title: 'Concierge playbooks',
+    title: 'Exclusive Featured Model pages for top performers',
     description:
-      'Digestible scripts, lighting notes, and boundary-first upsells captured on the blog with concierge follow-up when you need it.',
-    link: { href: '/blog', label: 'Read the latest preview' }
+      'Hit your milestones and earn a spotlight page that links directly to your room. We celebrate models who put in the work.',
+    link: { href: '/startright', label: 'See how to qualify' }
+  },
+  {
+    title: 'Secure, private, no B.S.',
+    description:
+      'You keep control of your accounts. We keep guidance discreet, with no contracts or pushy upsells — just real support.',
+    link: { href: '/privacy', label: 'Review our approach' }
   }
 ];
 ---
 <section class="border-t border-white/5 bg-midnight/40 px-6 py-20">
   <div class="mx-auto flex max-w-6xl flex-col gap-10">
     <div class="space-y-3 text-center">
-      <p class="mx-auto text-[clamp(0.75rem,1.2vw,0.9rem)] uppercase tracking-[0.4em] text-rose-petal/70">What you get</p>
-      <h2 class="font-display text-[clamp(2.1rem,5vw,3rem)] text-white">Proof, builds, and concierge guidance</h2>
+      <p class="mx-auto text-[clamp(0.75rem,1.2vw,0.9rem)] uppercase tracking-[0.4em] text-rose-petal/70">What is NCS?</p>
+      <h2 class="font-display text-[clamp(2.1rem,5vw,3rem)] text-white">NCS is your no-nonsense concierge</h2>
       <p class="mx-auto max-w-3xl text-[clamp(0.95rem,1.9vw,1.15rem)] text-white/70">
-        Instead of scattering previews everywhere, we bundle the essentials: transparent proof, example builds you can copy from,
-        and concierge playbooks that keep your launch grounded.
+        NCS connects you directly with top cam sites and rewards you for taking action. Sign up through a partner platform to
+        unlock VIP access to the StartRight Kit — a curated toolkit of insider guides, content templates, and onboarding tips
+        that help you launch faster and earn smarter.
       </p>
     </div>
     <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">


### PR DESCRIPTION
## Summary
- refresh homepage hero CTA and supporting copy with StartRight positioning
- update about, benefits, and how-it-works sections to highlight NCS onboarding flow
- align featured model spotlight content with new messaging

## Testing
- npm test *(fails: npm registry access returns 403 and missing module src/utils/programs referenced by tests)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69264c09067c832686298757451687b3)