### PR TITLE
Add StartRight username availability checker

### DIFF
--- a/public/api/namecheck.php
+++ b/public/api/namecheck.php
@@ -1,0 +1,284 @@
+<?php
+declare(strict_types=1);
+
+const NAMECHECK_USER_AGENT = 'Mozilla/5.0 NaughtyCamSpotNameCheck/1.0';
+const RATE_LIMIT_REQUESTS = 30;
+const RATE_LIMIT_WINDOW = 3600; // 1 hour
+const CACHE_TTL = 900; // 15 minutes
+
+header('Content-Type: application/json');
+
+function respond(int $status, array $payload): void
+{
+    http_response_code($status);
+    echo json_encode($payload);
+    exit;
+}
+
+function ensureDir(string $path): void
+{
+    if (!is_dir($path)) {
+        mkdir($path, 0777, true);
+    }
+}
+
+function httpRequest(string $url, array $options = []): array
+{
+    $ch = curl_init($url);
+
+    $timeout = $options['timeout'] ?? 5;
+    $headers = $options['headers'] ?? [];
+
+    curl_setopt_array($ch, [
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_FOLLOWLOCATION => true,
+        CURLOPT_TIMEOUT => $timeout,
+        CURLOPT_CONNECTTIMEOUT => $timeout,
+        CURLOPT_USERAGENT => NAMECHECK_USER_AGENT,
+        CURLOPT_HEADER => true,
+        CURLOPT_SSL_VERIFYPEER => true,
+        CURLOPT_SSL_VERIFYHOST => 2,
+    ]);
+
+    if (!empty($headers)) {
+        curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+    }
+
+    if (isset($options['post_fields'])) {
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, $options['post_fields']);
+    }
+
+    $raw = curl_exec($ch);
+    $error = $raw === false ? curl_error($ch) : null;
+    $status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    $headerSize = curl_getinfo($ch, CURLINFO_HEADER_SIZE);
+    $body = $raw !== false ? substr($raw, $headerSize) : '';
+    curl_close($ch);
+
+    return [
+        'status' => (int) $status,
+        'body' => $body,
+        'error' => $error,
+    ];
+}
+
+function rateLimit(string $ip): void
+{
+    $dir = sys_get_temp_dir() . '/ncs_namecheck_rate';
+    ensureDir($dir);
+    $file = $dir . '/' . sha1($ip ?: 'unknown');
+    $now = time();
+    $windowEnd = $now + RATE_LIMIT_WINDOW;
+    $record = [
+        'count' => 0,
+        'resetAt' => $windowEnd,
+    ];
+
+    if (file_exists($file)) {
+        $decoded = json_decode((string) file_get_contents($file), true);
+        if (is_array($decoded) && isset($decoded['count'], $decoded['resetAt'])) {
+            if ($decoded['resetAt'] > $now) {
+                $record = $decoded;
+            }
+        }
+    }
+
+    if ($record['resetAt'] <= $now) {
+        $record = [
+            'count' => 0,
+            'resetAt' => $now + RATE_LIMIT_WINDOW,
+        ];
+    }
+
+    if ($record['count'] >= RATE_LIMIT_REQUESTS) {
+        respond(429, [
+            'error' => 'rate_limited',
+            'resetAt' => gmdate('c', (int) $record['resetAt']),
+        ]);
+    }
+
+    $record['count']++;
+    file_put_contents($file, json_encode($record));
+}
+
+function readCache(string $canonical): ?array
+{
+    $dir = sys_get_temp_dir() . '/ncs_namecheck_cache';
+    ensureDir($dir);
+    $file = $dir . '/' . sha1($canonical) . '.json';
+    if (!file_exists($file)) {
+        return null;
+    }
+    $payload = json_decode((string) file_get_contents($file), true);
+    if (!is_array($payload) || !isset($payload['cachedAt'])) {
+        return null;
+    }
+    if ((time() - (int) $payload['cachedAt']) > CACHE_TTL) {
+        return null;
+    }
+    return $payload;
+}
+
+function writeCache(string $canonical, array $results): void
+{
+    $dir = sys_get_temp_dir() . '/ncs_namecheck_cache';
+    ensureDir($dir);
+    $file = $dir . '/' . sha1($canonical) . '.json';
+    $payload = [
+        'canonical' => $canonical,
+        'results' => $results,
+        'cachedAt' => time(),
+    ];
+    file_put_contents($file, json_encode($payload));
+}
+
+function isoNow(): string
+{
+    return gmdate('c');
+}
+
+function checkChaturbate(string $canonical): array
+{
+    $response = httpRequest('https://chaturbate.com/get_edge_hls_url_ajax/', [
+        'post_fields' => http_build_query(['room_slug' => $canonical]),
+    ]);
+
+    $status = 'UNKNOWN';
+    if (!$response['error']) {
+        $decoded = json_decode($response['body'], true);
+        if (is_array($decoded) && array_key_exists('success', $decoded)) {
+            if ($decoded['success'] === true) {
+                $status = 'TAKEN';
+            } elseif ($decoded['success'] === false) {
+                $status = 'AVAILABLE';
+            }
+        }
+    }
+
+    return [
+        'status' => $status,
+        'checkedAt' => isoNow(),
+    ];
+}
+
+function checkCamsoda(string $canonical): array
+{
+    $response = httpRequest("https://www.camsoda.com/api/v1/user/{$canonical}");
+
+    $status = 'UNKNOWN';
+    if (!$response['error']) {
+        if ($response['status'] === 404) {
+            $status = 'AVAILABLE';
+        } elseif ($response['status'] === 200) {
+            $decoded = json_decode($response['body'], true);
+            if (is_array($decoded)) {
+                $status = 'TAKEN';
+            }
+        }
+    }
+
+    return [
+        'status' => $status,
+        'checkedAt' => isoNow(),
+    ];
+}
+
+function checkBongaCams(string $canonical): array
+{
+    $response = httpRequest('https://bongacams.com/tools/amf.php', [
+        'post_fields' => http_build_query([
+            'method' => 'getRoomData',
+            'args[]' => $canonical,
+            'args[]' => '',
+            'args[]' => '',
+        ]),
+    ]);
+
+    $status = 'UNKNOWN';
+
+    if (!$response['error']) {
+        $body = $response['body'];
+        $decoded = json_decode($body, true);
+
+        if (is_array($decoded)) {
+            $encoded = json_encode($decoded);
+            $lowerEncoded = is_string($encoded) ? strtolower($encoded) : '';
+
+            if (
+                isset($decoded['error']) ||
+                (isset($decoded['status']) && in_array($decoded['status'], ['error', 'notfound', 'not_found'], true))
+            ) {
+                $status = 'AVAILABLE';
+            } elseif (
+                isset($decoded['performer']) ||
+                isset($decoded['room']) ||
+                isset($decoded['username']) ||
+                ($lowerEncoded && strpos($lowerEncoded, 'performer') !== false)
+            ) {
+                $status = 'TAKEN';
+            }
+        }
+
+        if ($status === 'UNKNOWN') {
+            $normalizedBody = strtolower($body);
+            if (
+                strpos($normalizedBody, 'no such room') !== false ||
+                strpos($normalizedBody, 'not found') !== false ||
+                strpos($normalizedBody, 'unknown room') !== false
+            ) {
+                $status = 'AVAILABLE';
+            } elseif (
+                strpos($normalizedBody, 'performer') !== false ||
+                strpos($normalizedBody, 'room_data') !== false ||
+                strpos($normalizedBody, 'username') !== false
+            ) {
+                $status = 'TAKEN';
+            }
+        }
+    }
+
+    return [
+        'status' => $status,
+        'checkedAt' => isoNow(),
+    ];
+}
+
+$rawInput = isset($_GET['name']) ? (string) $_GET['name'] : '';
+$canonical = strtolower(trim($rawInput));
+
+if ($canonical === '' || !preg_match('/^[a-z0-9_]{3,30}$/', $canonical)) {
+    respond(400, ['error' => 'invalid_name']);
+}
+
+$ip = $_SERVER['REMOTE_ADDR'] ?? 'unknown';
+rateLimit($ip);
+
+$cached = readCache($canonical);
+if ($cached !== null) {
+    respond(200, [
+        'input' => $rawInput,
+        'canonical' => $cached['canonical'],
+        'results' => $cached['results'],
+        'cached' => true,
+    ]);
+}
+
+$chaturbate = checkChaturbate($canonical);
+$camsoda = checkCamsoda($canonical);
+$bongacams = checkBongaCams($canonical);
+
+$results = [
+    'chaturbate' => $chaturbate,
+    'camsoda' => $camsoda,
+    'bongacams' => $bongacams,
+];
+
+writeCache($canonical, $results);
+
+respond(200, [
+    'input' => $rawInput,
+    'canonical' => $canonical,
+    'results' => $results,
+    'cached' => false,
+]);

--- a/src/pages/startright.astro
+++ b/src/pages/startright.astro
@@ -53,6 +53,7 @@ const startRightGearHighlights = gearKits.map((kit) => ({
   conciergeNote: kit.conciergeNote
 }));
 
+const desiredUsername = Astro.url.searchParams.get('desiredUsername');
 const basePrograms = enrichedPrograms
   .filter((program) => isProgramApproved(program) && allowsPagesJoin(program))
   .map((program) => {
@@ -205,7 +206,7 @@ const clientPrograms = JSON.stringify(
         Tune the inputs to match your situation. We&apos;ll translate those signals into a ranked list of partner programs, share
         why they fit, and route you to the guarded links you need to unlock the StartRight launch kit.
       </p>
-      <div class="flex flex-col gap-3 sm:flex-row sm:items-center">
+      <div class="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center">
         <LinkCTA
           class="border border-rose-gold/60 bg-rose-gold text-midnight text-sm tracking-[0.2em] shadow-glow"
           pagesHref={PRIMARY_CTA.pagesHref}
@@ -218,7 +219,19 @@ const clientPrograms = JSON.stringify(
           prodHref={skipHrefProd}
           label={STARTRIGHT_SKIP.label}
         />
+        <LinkCTA
+          class="btn btn-secondary w-full sm:w-auto"
+          pagesHref="/startright/name-check"
+          prodHref="/startright/name-check"
+          label="Step 2: Check Name Availability"
+        />
       </div>
+      {desiredUsername && (
+        <div class="inline-flex items-center gap-2 rounded-full border border-emerald-400/40 bg-emerald-500/10 px-4 py-2 text-sm text-emerald-100">
+          <span class="text-xs uppercase tracking-[0.35em] text-emerald-200">Selected username</span>
+          <span class="font-semibold text-white">{desiredUsername}</span>
+        </div>
+      )}
     </div>
     <form id="startright-form" class="grid gap-6 rounded-[32px] border border-white/10 bg-white/5 p-6 backdrop-blur-2xl">
       <div class="grid gap-4 sm:grid-cols-2">

--- a/src/pages/startright/name-check.astro
+++ b/src/pages/startright/name-check.astro
@@ -1,0 +1,299 @@
+---
+import LinkCTA from '../../components/LinkCTA.astro';
+import SEO from '../../components/SEO.astro';
+import MainLayout from '../../layouts/MainLayout.astro';
+
+const canonicalPath = '/startright/name-check';
+const platforms = [
+  { key: 'chaturbate', label: 'Chaturbate' },
+  { key: 'camsoda', label: 'CamSoda' },
+  { key: 'bongacams', label: 'BongaCams' }
+];
+---
+
+<MainLayout
+  title="Check username availability | StartRight | NaughtyCamSpot"
+  description="Verify your model username across Chaturbate, CamSoda, and BongaCams before you lock in your StartRight plan."
+>
+  <SEO
+    slot="head"
+    title="Check username availability | StartRight | NaughtyCamSpot"
+    description="Check availability across Chaturbate, CamSoda, and BongaCams with one quick lookup."
+    path={canonicalPath}
+  />
+  <section class="space-y-8">
+    <div class="space-y-4">
+      <p class="text-xs uppercase tracking-[0.35em] text-rose-petal/70">Step 2: Name check</p>
+      <h1 class="font-display text-4xl text-white sm:text-5xl">Lock in your model username</h1>
+      <p class="max-w-3xl text-base text-white/70">
+        Enter a single username to see if it&apos;s available on Chaturbate, CamSoda, and BongaCams. We only let you continue when
+        all three are free so you don&apos;t get stuck mid-setup.
+      </p>
+      <div class="flex flex-col gap-3 sm:flex-row sm:items-center">
+        <LinkCTA
+          class="border border-white/15 bg-transparent text-white/80 hover:border-white/30 hover:bg-white/10 hover:text-white"
+          pagesHref="/startright"
+          prodHref="/startright"
+          label="Back to Step 1"
+        />
+        <p class="text-xs text-white/60">We cache checks for 15 minutes to keep things fast.</p>
+      </div>
+    </div>
+
+    <section class="space-y-6 rounded-[32px] border border-white/10 bg-white/5 p-6 backdrop-blur-2xl">
+      <form id="namecheck-form" class="space-y-3">
+        <label class="space-y-2 text-sm text-white/70">
+          <span class="text-xs uppercase tracking-[0.35em] text-rose-petal/70">Desired username</span>
+          <input
+            id="desired-name"
+            name="name"
+            type="text"
+            inputmode="text"
+            autocomplete="off"
+            spellcheck="false"
+            class="w-full rounded-full border border-white/15 bg-white/5 px-4 py-3 text-base text-white/90 focus:border-rose-gold focus:outline-none focus:ring-2 focus:ring-rose-gold/40"
+            placeholder="3-30 characters, letters / numbers / underscore"
+            required
+            minlength="3"
+            maxlength="30"
+          />
+        </label>
+        <div class="flex flex-col gap-3 sm:flex-row sm:items-center">
+          <button
+            id="check-button"
+            type="submit"
+            class="inline-flex items-center justify-center rounded-full border border-rose-gold/60 bg-rose-gold px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-midnight shadow-glow transition hover:-translate-y-1 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            Check availability
+          </button>
+          <p id="namecheck-message" class="text-sm text-white/60"></p>
+        </div>
+      </form>
+
+      <div class="space-y-3">
+        <p class="text-sm text-white/60">Status per platform</p>
+        <div class="grid gap-4 md:grid-cols-3">
+          {platforms.map((platform) => (
+            <article
+              data-platform={platform.key}
+              class="rounded-2xl border border-white/10 bg-black/30 p-4 shadow-inner"
+            >
+              <header class="flex items-start justify-between gap-3">
+                <div>
+                  <p class="text-xs uppercase tracking-[0.35em] text-rose-petal/70">{platform.label}</p>
+                  <p class="text-xs text-white/50" data-checked-at="">{'\u00a0'}</p>
+                </div>
+                <span
+                  data-status-pill=""
+                  class="inline-flex items-center justify-center rounded-full border border-white/15 bg-white/5 px-4 py-1 text-[11px] font-semibold uppercase tracking-[0.3em] text-white/60"
+                >
+                  Not checked
+                </span>
+              </header>
+              <p class="mt-3 text-sm text-white/70" data-status-note="">Waiting for your check.</p>
+            </article>
+          ))}
+        </div>
+      </div>
+
+      <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <LinkCTA
+          class="border border-white/15 bg-transparent text-white/80 hover:border-white/30 hover:bg-white/10 hover:text-white"
+          pagesHref="/startright"
+          prodHref="/startright"
+          label="Back to Step 1"
+        />
+        <button
+          id="continue-button"
+          type="button"
+          class="inline-flex items-center justify-center rounded-full border border-emerald-400/60 bg-emerald-500 px-6 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-midnight shadow-glow transition hover:-translate-y-1 disabled:cursor-not-allowed disabled:opacity-60"
+          disabled
+        >
+          Continue
+        </button>
+      </div>
+      <p class="text-xs text-white/55">
+        We run checks server-side with timeouts and rate limits. Continue becomes available only when all three platforms are clear.
+      </p>
+    </section>
+  </section>
+
+  <script is:inline>
+    const form = document.querySelector('#namecheck-form');
+    const input = document.querySelector('#desired-name');
+    const checkButton = document.querySelector('#check-button');
+    const continueButton = document.querySelector('#continue-button');
+    const message = document.querySelector('#namecheck-message');
+    const storageKey = 'signupDesiredUsername';
+    const statusPills = new Map();
+    const statusNotes = new Map();
+    const checkedAtEls = new Map();
+    const platformOrder = ['chaturbate', 'camsoda', 'bongacams'];
+    let lastCanonical = '';
+
+    const statusClasses = {
+      AVAILABLE: 'border-emerald-400/60 bg-emerald-500/15 text-emerald-200',
+      TAKEN: 'border-rose-400/60 bg-rose-500/15 text-rose-100',
+      UNKNOWN: 'border-white/20 bg-white/10 text-white/70',
+      PENDING: 'border-white/15 bg-white/5 text-white/60'
+    };
+
+    const statusNotesCopy = {
+      AVAILABLE: 'Open — looks clear on this platform.',
+      TAKEN: 'Already registered. Try another username.',
+      UNKNOWN: 'Could not confirm. Please try again.',
+      PENDING: 'Waiting for your check.'
+    };
+
+    const initMaps = () => {
+      document.querySelectorAll('[data-platform]').forEach((node) => {
+        const key = node.getAttribute('data-platform');
+        const pill = node.querySelector('[data-status-pill]');
+        const note = node.querySelector('[data-status-note]');
+        const checkedAt = node.querySelector('[data-checked-at]');
+        if (key) {
+          statusPills.set(key, pill);
+          statusNotes.set(key, note);
+          checkedAtEls.set(key, checkedAt);
+        }
+      });
+    };
+
+    const setPill = (key, status) => {
+      const pill = statusPills.get(key);
+      const note = statusNotes.get(key);
+      const checkedAt = checkedAtEls.get(key);
+      if (!pill || !note) return;
+      pill.textContent = status === 'PENDING' ? 'Not checked' : status;
+      pill.className =
+        'inline-flex items-center justify-center rounded-full border px-4 py-1 text-[11px] font-semibold uppercase tracking-[0.3em] transition ' +
+        (statusClasses[status] || statusClasses.PENDING);
+      note.textContent = statusNotesCopy[status] || '';
+      if (checkedAt) {
+        checkedAt.textContent = status === 'PENDING' ? '\u00a0' : `Checked ${new Date().toLocaleTimeString()}`;
+      }
+    };
+
+    const resetStatuses = () => {
+      platformOrder.forEach((key) => setPill(key, 'PENDING'));
+      continueButton.disabled = true;
+      continueButton.setAttribute('aria-disabled', 'true');
+    };
+
+    const updateFromResults = (results = {}) => {
+      let allAvailable = true;
+      platformOrder.forEach((key) => {
+        const entry = results[key];
+        const status = entry && entry.status ? String(entry.status).toUpperCase() : 'UNKNOWN';
+        setPill(key, status);
+        const checkedAt = checkedAtEls.get(key);
+        if (checkedAt && entry && entry.checkedAt) {
+          checkedAt.textContent = `Checked ${new Date(entry.checkedAt).toLocaleTimeString()}`;
+        }
+        if (status !== 'AVAILABLE') {
+          allAvailable = false;
+        }
+      });
+      continueButton.disabled = !allAvailable;
+      continueButton.setAttribute('aria-disabled', allAvailable ? 'false' : 'true');
+      if (allAvailable && lastCanonical) {
+        try {
+          localStorage.setItem(storageKey, lastCanonical);
+        } catch (error) {
+          // ignore storage issues silently
+        }
+      }
+    };
+
+    const setLoading = (isLoading) => {
+      if (isLoading) {
+        checkButton.setAttribute('disabled', 'true');
+        checkButton.textContent = 'Checking...';
+      } else {
+        checkButton.removeAttribute('disabled');
+        checkButton.textContent = 'Check availability';
+      }
+    };
+
+    const showMessage = (text, tone = 'info') => {
+      if (!message) return;
+      message.textContent = text;
+      message.className =
+        'text-sm ' +
+        (tone === 'error'
+          ? 'text-rose-200'
+          : tone === 'success'
+            ? 'text-emerald-200'
+            : 'text-white/70');
+    };
+
+    const prefillFromStorage = () => {
+      try {
+        const stored = localStorage.getItem(storageKey);
+        if (stored && !input.value) {
+          input.value = stored;
+        }
+      } catch (error) {
+        // ignore storage access issues
+      }
+    };
+
+    const runCheck = async () => {
+      const value = input.value.trim();
+      if (!value) {
+        showMessage('Enter a username to check availability.', 'error');
+        return;
+      }
+      resetStatuses();
+      setLoading(true);
+      showMessage('');
+      try {
+        const response = await fetch(`/api/namecheck.php?name=${encodeURIComponent(value)}`, {
+          headers: { Accept: 'application/json' }
+        });
+        const data = await response.json();
+        if (!response.ok) {
+          const errorCode = data && data.error ? data.error : 'request_failed';
+          showMessage(errorCode === 'invalid_name' ? 'Username must be 3-30 characters (letters, numbers, underscore).' : 'Unable to process your request right now.', 'error');
+          return;
+        }
+        lastCanonical = data.canonical || value.toLowerCase();
+        updateFromResults(data.results);
+        if (continueButton.disabled) {
+          showMessage('We need all three platforms to be AVAILABLE before you continue.', 'info');
+        } else {
+          showMessage('Great — that username is available everywhere.', 'success');
+        }
+      } catch (error) {
+        showMessage('Network error. Please try again.', 'error');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    form?.addEventListener('submit', (event) => {
+      event.preventDefault();
+      runCheck();
+    });
+
+    input?.addEventListener('input', () => {
+      resetStatuses();
+      showMessage('');
+    });
+
+    continueButton?.addEventListener('click', () => {
+      if (continueButton.disabled || !lastCanonical) return;
+      try {
+        localStorage.setItem(storageKey, lastCanonical);
+      } catch (error) {
+        // ignore storage issues
+      }
+      const destination = `/startright/?desiredUsername=${encodeURIComponent(lastCanonical)}`;
+      window.location.href = destination;
+    });
+
+    initMaps();
+    resetStatuses();
+    prefillFromStorage();
+  </script>
+</MainLayout>


### PR DESCRIPTION
## Summary
- add a server-side name availability endpoint covering CamSoda, Chaturbate, and BongaCams with validation, caching, and rate limiting
- build the StartRight Step 2 name-check page that checks all platforms, gates continuation on availability, and stores the chosen username
- link Step 1 to the checker and surface the selected username when returning to the flow

## Testing
- npm run lint *(fails: ESLint could not find an eslint.config.* file in this repo)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695779722c888326a8c71230f1d36067)