### PR TITLE
Update hero CTA test for new signup copy

### DIFF
--- a/tests/home-hero-cta.test.mjs
+++ b/tests/home-hero-cta.test.mjs
@@ -15,10 +15,11 @@ test('Primary CTA routes to StartRight in all environments', async () => {
   assert.ok(copySource.includes("prodHref: '/startright'"), 'Production href should point to /startright');
 });
 
-test('Hero partial keeps a single StartRight CTA', async () => {
+test('Hero partial surfaces the model signup CTA', async () => {
   const heroSource = await readSource('src/partials/home/Hero.astro');
-  assert.ok(heroSource.includes('Get my StartRight Kit →'), 'Hero partial should show the StartRight CTA label');
-  assert.ok(!heroSource.includes('/join-models'), 'Hero partial should not link to /join-models');
+  assert.ok(heroSource.includes('Model Signup — Start Here'), 'Hero partial should show the model signup CTA label');
+  assert.ok(heroSource.includes('pagesHref=\"/join-models\"'), 'Hero partial should link to /join-models for Pages builds');
+  assert.ok(heroSource.includes('prodHref=\"/join-models\"'), 'Hero partial should link to /join-models for production builds');
 });
 
 test('Hero partial avoids tracked /go/ links', async () => {


### PR DESCRIPTION
## Summary
- update the homepage hero CTA test to expect the current model signup copy and /join-models target for both build modes

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958836187cc8326942b8fa038a1fb04)