### PR TITLE
Fix: add topics/version metadata to blog posts

### DIFF
--- a/src/content/blog/14-day-launch-plan.md
+++ b/src/content/blog/14-day-launch-plan.md
@@ -8,6 +8,8 @@ author: 'Lina, Data Strategist'
 heroImage: 'https://images.unsplash.com/photo-1529333166437-7750a6dd5a70?auto=format&fit=crop&w=1600&q=80'
 heroImageAlt: 'Daily planner with handwritten show schedule'
 cardImage: 'https://images.unsplash.com/photo-1506784983877-45594efa4cbe?auto=format&fit=crop&w=1200&q=80'
+topics: ['work-money']
+version: 2
 ---
 
 ## Phase 1: Orientation (Days 1–3)

--- a/src/content/blog/bongacash-model-bounty-tiers.md
+++ b/src/content/blog/bongacash-model-bounty-tiers.md
@@ -8,6 +8,8 @@ author: 'Elena, Head of Growth'
 heroImage: 'https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=1600&q=80'
 heroImageAlt: 'Close-up of a performer planning strategy on a glass board'
 cardImage: 'https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1200&q=80'
+topics: ['work-money']
+version: 2
 ---
 
 ## How the bounty ladder works

--- a/src/content/blog/camsoda-vs-chaturbate-for-beginners.md
+++ b/src/content/blog/camsoda-vs-chaturbate-for-beginners.md
@@ -8,6 +8,8 @@ author: 'Concierge Team'
 heroImage: 'https://images.unsplash.com/photo-1530035415919-d499f3fbeaa4?auto=format&fit=crop&w=1600&q=80'
 heroImageAlt: 'Performer framed by two neon spotlights in a dark studio'
 cardImage: 'https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=1200&q=80'
+topics: ['work-money']
+version: 2
 ---
 
 ## Why this decision matters

--- a/src/content/blog/earnings-levers-that-matter.md
+++ b/src/content/blog/earnings-levers-that-matter.md
@@ -8,6 +8,8 @@ author: 'Mara, Performance Lead'
 heroImage: 'https://images.unsplash.com/photo-1450101499163-c8848c66ca85?auto=format&fit=crop&w=1600&q=80'
 heroImageAlt: 'Performer reviewing notes with a coach'
 cardImage: 'https://images.unsplash.com/photo-1460925895917-afdab827c52f?auto=format&fit=crop&w=1200&q=80'
+topics: ['work-money']
+version: 2
 ---
 
 Every recruitment push starts with the levers we can pull without asking the platform for mercy. We audit your baseline, surface two quick wins, and model the compounding effect before we ever add a new traffic source.

--- a/src/content/blog/first-30-days-checklist.md
+++ b/src/content/blog/first-30-days-checklist.md
@@ -8,6 +8,8 @@ author: 'Tess, Launch Producer'
 heroImage: 'https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=1600&q=80'
 heroImageAlt: 'Wall calendar with sticky notes'
 cardImage: 'https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=1200&q=80'
+topics: ['work-money']
+version: 2
 ---
 
 The first month should feel like a guided runway, not a scramble. We split your tasks into four weekly packets so you always know what matters right now.

--- a/src/content/blog/first-stream-checklist-under-100.md
+++ b/src/content/blog/first-stream-checklist-under-100.md
@@ -8,6 +8,8 @@ author: 'Milo, Community Director'
 heroImage: 'https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=1600&q=80'
 heroImageAlt: 'Budget-friendly streaming setup with tripod light and laptop'
 cardImage: 'https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=1200&q=80'
+topics: ['work-money']
+version: 2
 ---
 
 ## Set the foundation

--- a/src/content/blog/price-ladders-and-goals-for-beginners.md
+++ b/src/content/blog/price-ladders-and-goals-for-beginners.md
@@ -8,6 +8,8 @@ author: 'Jules, Conversion Coach'
 heroImage: 'https://images.unsplash.com/photo-1523580846011-d3a5bc25702b?auto=format&fit=crop&w=1600&q=80'
 heroImageAlt: 'Performer arranging tip menu cards'
 cardImage: 'https://images.unsplash.com/photo-1545239351-ef35f43d514b?auto=format&fit=crop&w=1200&q=80'
+topics: ['work-money']
+version: 2
 ---
 
 We onboard new models with the most repeatable structure we have: three prices, three experiences, and one story arc per stream. It eliminates decision fatigue and keeps your pacing clean.

--- a/src/content/blog/thanksgiving-week-strategy.md
+++ b/src/content/blog/thanksgiving-week-strategy.md
@@ -8,6 +8,8 @@ author: "NaughtyCamSpot Concierge Team"
 heroImage: "/illustrations/thanksgiving-week-strategy/thanksgiving-week-strategy-hero.png"
 heroImageAlt: "Model preparing a Thanksgiving streaming schedule with a planner and laptop"
 cardImage: "/illustrations/thanksgiving-week-strategy/thanksgiving-week-strategy-hero.png"
+topics: ['work-money']
+version: 2
 ---
 
 # Thanksgiving Week: Simple Strategy Guide for Models

--- a/src/content/blog/top-supporter-recognition.md
+++ b/src/content/blog/top-supporter-recognition.md
@@ -9,6 +9,8 @@ heroImage: "/illustrations/top-supporter-recognition/top-supporter-recognition-h
 heroImageAlt: "Year-end appreciation from a model to top supporters with VIP recognition and festive gratitude"
 cardImage: "/illustrations/top-supporter-recognition/top-supporter-recognition-hero.png"
 suppressCtas: true
+topics: ['work-money']
+version: 2
 ---
 
 Year-end appreciation is one of the **highest-leverage moments** a model has — *if it’s done correctly*.

--- a/src/content/blog/where-the-viewers-are-2025.md
+++ b/src/content/blog/where-the-viewers-are-2025.md
@@ -8,6 +8,8 @@ author: 'Lina, Data Strategist'
 heroImage: 'https://images.unsplash.com/photo-1522202176988-66273c2fd55f?auto=format&fit=crop&w=1600&q=80'
 heroImageAlt: 'Global map with highlighted regions'
 cardImage: 'https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1200&q=80'
+topics: ['work-money']
+version: 2
 ---
 
 Our concierge tracker pulls hourly breakouts from the partner networks, so we see when each geography comes alive. Slot your hero shows where the bars are darkest and keep lighter programming in the low bands.

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,4 +1,5 @@
 import { defineCollection, z } from 'astro:content';
+import { topicKeys } from '../data/categories';
 
 const platformSchema = z.object({
   name: z.string(),
@@ -20,6 +21,7 @@ const trackingSchema = z
 
 const localPath = z.string().refine((val) => val.startsWith('/'), { message: 'Must start with / for local assets' });
 const urlOrPath = z.union([z.string().url(), localPath]);
+const topicEnum = z.enum(topicKeys);
 
 const models = defineCollection({
   type: 'data',
@@ -53,6 +55,8 @@ const blog = defineCollection({
     heroImage: urlOrPath,
     heroImageAlt: z.string().optional(),
     cardImage: urlOrPath.optional(),
+    topics: z.array(topicEnum).min(1),
+    version: z.number().int().min(1),
     suppressCtas: z.boolean().default(false),
     vipOnly: z.boolean().default(false)
   })

--- a/src/data/categories.ts
+++ b/src/data/categories.ts
@@ -1,0 +1,8 @@
+export const topicKeys = ['system-shock', 'work-money'] as const;
+
+export type TopicKey = (typeof topicKeys)[number];
+
+export const topicLabels: Record<TopicKey, string> = {
+  'system-shock': 'System Shock',
+  'work-money': 'Work & Money'
+};


### PR DESCRIPTION
## Summary
- add topic keys and enforce topics/version in blog collection schema
- fill missing topics/version frontmatter across blog posts with defaults

## Testing
- `npm test` *(fails: existing CTA/link expectations in fixtures)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69588863dff083268092a688fabe6d15)