### PR TITLE
#119 Add promoOffer single source of truth

### DIFF
--- a/src/data/promoOffer.ts
+++ b/src/data/promoOffer.ts
@@ -1,0 +1,67 @@
+export type PromoOfferPlan = {
+  slug: string;
+  name: string;
+  price: string;
+  deliverables: string[];
+  gates: string[];
+};
+
+export type PromoOffer = {
+  sprintOffers: PromoOfferPlan[];
+  monthlyTiers: PromoOfferPlan[];
+  addOns: string[];
+  nonNegotiables: string;
+  supportedPlatforms: {
+    live: string[];
+    comingSoon: string[];
+  };
+};
+
+export const promoOffer: PromoOffer = {
+  sprintOffers: [
+    {
+      slug: 'lite-7',
+      name: '7-day Lite',
+      price: '$XXX',
+      deliverables: ['One platform sprint checklist', 'Daily execution notes', 'End-of-sprint recap'],
+      gates: ['Model provides approved media pack', 'Model approves plan before launch']
+    },
+    {
+      slug: 'sprint-14',
+      name: '14-day Sprint',
+      price: '$XXX',
+      deliverables: ['Two-week promo calendar', 'Offer ladder setup', 'Twice-weekly performance review'],
+      gates: ['Model provides weekly content batches', 'Model responds to approvals within 24 hours']
+    }
+  ],
+  monthlyTiers: [
+    {
+      slug: 'launch-lite',
+      name: 'Launch Lite',
+      price: '$XXX/mo',
+      deliverables: ['Single-platform monthly plan', 'Caption and CTA template pack', 'Weekly check-ins'],
+      gates: ['Model provides platform links and goals', 'Model provides posting windows']
+    },
+    {
+      slug: 'growth-engine',
+      name: 'Growth Engine',
+      price: '$XXX/mo',
+      deliverables: ['Two-platform growth plan', 'Offer and retention testing', 'Twice-weekly optimization notes'],
+      gates: ['Model provides weekly content batches', 'Model approves updates in 24 hours']
+    },
+    {
+      slug: 'operator',
+      name: 'Operator',
+      price: '$XXX/mo',
+      deliverables: ['Priority roadmap and experiments', 'Weekly reporting and planning call notes', 'Dedicated review support'],
+      gates: ['Model confirms monthly goals and limits', 'Model confirms budget and promo constraints']
+    }
+  ],
+  addOns: ['Profile setup polish', 'Landing page audit', 'Extra reporting pack', 'Priority weekend support window'],
+  nonNegotiables:
+    'No passwords or logins. No exclusivity. Model owns accounts and content. No spam DM automation. Cancel anytime. No earnings guarantees.',
+  supportedPlatforms: {
+    live: ['Chaturbate', 'CamSoda', 'BongaCams'],
+    comingSoon: ['Stripchat']
+  }
+};

--- a/src/pages/packages.astro
+++ b/src/pages/packages.astro
@@ -3,6 +3,7 @@ import MainLayout from '../layouts/MainLayout.astro';
 import SEO from '../components/SEO.astro';
 import { withBase } from '../utils/links';
 import { getRequestLang, t } from '../i18n/core';
+import { promoOffer } from '../data/promoOffer';
 
 const canonicalPath = '/packages';
 const lang = getRequestLang(Astro.url);
@@ -77,7 +78,13 @@ const faqItems = [
       <p class="max-w-3xl text-base text-white/75">
         Each package is phone-first: clear tasks, clear handoff, clear trust rules.
       </p>
-      <p class="text-sm text-white/70">Trust policy: no passwords, no exclusivity, you own accounts and content, cancel anytime.</p>
+      <p class="text-sm text-white/70">Trust policy: {promoOffer.nonNegotiables}</p>
+    </div>
+
+    <div class="content-card space-y-3">
+      <h2 class="font-display text-2xl text-white">Supported promo platforms</h2>
+      <p class="text-sm text-white/75">Live now: {promoOffer.supportedPlatforms.live.join(', ')}</p>
+      <p class="text-sm text-white/60">Coming soon: {promoOffer.supportedPlatforms.comingSoon.join(', ')}</p>
     </div>
 
     <div class="grid gap-5">


### PR DESCRIPTION
### Motivation
- Provide a single canonical data source for promotion offerings and trust copy so multiple pages don’t hardcode promo details.
- Surface supported promo platform scope from one place so live vs coming-soon status is consistent across the site.

### Description
- Add `src/data/promoOffer.ts` which exports typed `promoOffer` containing sprint offers, monthly tiers, add-ons, a non-negotiables trust block, and supported platforms (`live` and `comingSoon`).
- Wire `promoOffer` into `src/pages/packages.astro` by importing it and replacing the hardcoded trust policy string with `promoOffer.nonNegotiables` and rendering a “Supported promo platforms” section from `promoOffer.supportedPlatforms`.
- Kept changes minimal and local to the required surface so existing package tier cards and CTAs remain unchanged.

### Testing
- Ran `npm test`, which exercised unit/node tests and partially executed but several build-based tests failed because the environment cannot fetch dependencies from the npm registry (npm 403 forbidden during build steps).
- Ran `npm run build`, which failed because `astro` is not installed in this environment and `npm install` is blocked by the same registry 403 error.
- The `promoOffer` module exports cleanly and is imported by `/packages` (file-level import validated), and the rendered sections in `src/pages/packages.astro` now draw platform and non-negotiables values from that module.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a12237f3808326bcd5af9a65f53e44)