### PR TITLE
#119 promoOffer single source of truth

### DIFF
--- a/src/data/promoOffer.ts
+++ b/src/data/promoOffer.ts
@@ -1,66 +1,108 @@
-export type PromoOfferPlan = {
-  slug: string;
-  name: string;
+type PromoPlan = {
+  id: string;
+  displayName: string;
   price: string;
+  timeline: string;
   deliverables: string[];
   gates: string[];
 };
 
-export type PromoOffer = {
-  sprintOffers: PromoOfferPlan[];
-  monthlyTiers: PromoOfferPlan[];
-  addOns: string[];
-  nonNegotiables: string;
-  supportedPlatforms: {
+type PromoAddOn = {
+  id: string;
+  name: string;
+  price: string;
+  description: string;
+};
+
+export const promoOffer: {
+  sprintOffers: PromoPlan[];
+  monthlyTiers: PromoPlan[];
+  addOns: PromoAddOn[];
+  nonNegotables: string[];
+  platformScope: {
     live: string[];
     comingSoon: string[];
   };
-};
-
-export const promoOffer: PromoOffer = {
+} = {
   sprintOffers: [
     {
-      slug: 'lite-7',
-      name: '7-day Lite',
+      id: 'lite-7',
+      displayName: '7-day Lite',
       price: '$XXX',
+      timeline: '7 days',
       deliverables: ['One platform sprint checklist', 'Daily execution notes', 'End-of-sprint recap'],
       gates: ['Model provides approved media pack', 'Model approves plan before launch']
     },
     {
-      slug: 'sprint-14',
-      name: '14-day Sprint',
+      id: 'sprint-14',
+      displayName: '14-day Sprint',
       price: '$XXX',
+      timeline: '14 days',
       deliverables: ['Two-week promo calendar', 'Offer ladder setup', 'Twice-weekly performance review'],
       gates: ['Model provides weekly content batches', 'Model responds to approvals within 24 hours']
     }
   ],
   monthlyTiers: [
     {
-      slug: 'launch-lite',
-      name: 'Launch Lite',
+      id: 'launch-lite',
+      displayName: 'Launch Lite',
       price: '$XXX/mo',
+      timeline: 'Monthly',
       deliverables: ['Single-platform monthly plan', 'Caption and CTA template pack', 'Weekly check-ins'],
       gates: ['Model provides platform links and goals', 'Model provides posting windows']
     },
     {
-      slug: 'growth-engine',
-      name: 'Growth Engine',
+      id: 'growth-engine',
+      displayName: 'Growth Engine',
       price: '$XXX/mo',
+      timeline: 'Monthly',
       deliverables: ['Two-platform growth plan', 'Offer and retention testing', 'Twice-weekly optimization notes'],
       gates: ['Model provides weekly content batches', 'Model approves updates in 24 hours']
     },
     {
-      slug: 'operator',
-      name: 'Operator',
+      id: 'operator',
+      displayName: 'Operator',
       price: '$XXX/mo',
+      timeline: 'Monthly',
       deliverables: ['Priority roadmap and experiments', 'Weekly reporting and planning call notes', 'Dedicated review support'],
       gates: ['Model confirms monthly goals and limits', 'Model confirms budget and promo constraints']
     }
   ],
-  addOns: ['Profile setup polish', 'Landing page audit', 'Extra reporting pack', 'Priority weekend support window'],
-  nonNegotiables:
-    'No passwords or logins. No exclusivity. Model owns accounts and content. No spam DM automation. Cancel anytime. No earnings guarantees.',
-  supportedPlatforms: {
+  addOns: [
+    {
+      id: 'profile-polish',
+      name: 'Profile setup polish',
+      price: '$XXX',
+      description: 'Profile review and setup recommendations before launch.'
+    },
+    {
+      id: 'landing-audit',
+      name: 'Landing page audit',
+      price: '$XXX',
+      description: 'Conversion-focused review with prioritized improvements.'
+    },
+    {
+      id: 'reporting-pack',
+      name: 'Extra reporting pack',
+      price: '$XXX',
+      description: 'Additional weekly performance report snapshots.'
+    },
+    {
+      id: 'priority-weekend',
+      name: 'Priority weekend support window',
+      price: '$XXX',
+      description: 'Priority response window for weekend campaign adjustments.'
+    }
+  ],
+  nonNegotables: [
+    'No passwords/logins',
+    'No exclusivity',
+    'Model owns accounts/content',
+    'No spam DM automation',
+    'Cancel anytime',
+    'No earnings guarantees'
+  ],
+  platformScope: {
     live: ['Chaturbate', 'CamSoda', 'BongaCams'],
     comingSoon: ['Stripchat']
   }

--- a/src/pages/packages.astro
+++ b/src/pages/packages.astro
@@ -78,13 +78,21 @@ const faqItems = [
       <p class="max-w-3xl text-base text-white/75">
         Each package is phone-first: clear tasks, clear handoff, clear trust rules.
       </p>
-      <p class="text-sm text-white/70">Trust policy: {promoOffer.nonNegotiables}</p>
+      <p class="text-sm text-white/70">Trust policy: {promoOffer.nonNegotables.join('. ')}.</p>
+      <p class="text-sm text-white/70">Core rules: no passwords, no exclusivity, you own accounts and content.</p>
     </div>
 
     <div class="content-card space-y-3">
       <h2 class="font-display text-2xl text-white">Supported promo platforms</h2>
-      <p class="text-sm text-white/75">Live now: {promoOffer.supportedPlatforms.live.join(', ')}</p>
-      <p class="text-sm text-white/60">Coming soon: {promoOffer.supportedPlatforms.comingSoon.join(', ')}</p>
+      <p class="text-sm text-white/75">Live now: {promoOffer.platformScope.live.join(', ')}</p>
+      <p class="text-sm text-white/60">Coming soon: {promoOffer.platformScope.comingSoon.join(', ')}</p>
+    </div>
+
+    <div class="content-card space-y-3">
+      <h2 class="font-display text-xl text-white">Powered by promoOffer</h2>
+      <p class="text-sm text-white/75">
+        Sprint offers: {promoOffer.sprintOffers.map((offer) => offer.displayName).join(', ')}
+      </p>
     </div>
 
     <div class="grid gap-5">


### PR DESCRIPTION
Implements issue #119 by adding promoOffer as a single source of truth and wiring a minimal usage block into /packages.