### PR TITLE
[#120] Resolve packages promoOffer merge conflicts

### DIFF
--- a/src/pages/packages.astro
+++ b/src/pages/packages.astro
@@ -8,36 +8,9 @@ import { promoOffer } from '../data/promoOffer';
 const canonicalPath = '/packages';
 const lang = getRequestLang(Astro.url);
 const buildApplyHref = (pkg: string) => {
-  const params = new URLSearchParams({ track: 'promotion', package: pkg });
-  return `${withBase('/apply/')}?${params.toString()}`;
+  const params = new URLSearchParams({ package: pkg });
+  return `${withBase('/apply/promo')}?${params.toString()}`;
 };
-
-const packageTiers = [
-  {
-    slug: 'starter',
-    label: 'Starter',
-    name: 'Starter Plan',
-    deliverables: ['One platform start plan', 'Caption + post template pack', 'Weekly check-in'],
-    modelProvides: ['Brand photos or clips', 'Posting windows', 'Platform links and goals'],
-    weDoNotDo: ['No password requests', 'No account ownership transfer', 'No exclusivity contract']
-  },
-  {
-    slug: 'growth',
-    label: 'Mid',
-    name: 'Growth Plan',
-    deliverables: ['Two-platform weekly plan', 'Offer ladder + repeat fan tips', 'Twice-weekly improve notes'],
-    modelProvides: ['Content batches every week', 'Priority markets and budget target', 'Approval turnaround within 24h'],
-    weDoNotDo: ['No password requests', 'No lock-in terms', 'No earnings guarantees']
-  },
-  {
-    slug: 'scale',
-    label: 'Pro',
-    name: 'Pro Plan',
-    deliverables: ['Custom growth tests', 'Priority weekly reports', 'Dedicated review help'],
-    modelProvides: ['Plan approvals', 'Ad spend agreement', 'Monthly goals and limits'],
-    weDoNotDo: ['No password requests', 'No exclusivity requirement', 'No control over your account payouts']
-  }
-] as const;
 
 const faqItems = [
   {
@@ -88,29 +61,24 @@ const faqItems = [
       <p class="text-sm text-white/60">Coming soon: {promoOffer.platformScope.comingSoon.join(', ')}</p>
     </div>
 
-    <div class="content-card space-y-3">
-      <h2 class="font-display text-xl text-white">Powered by promoOffer</h2>
-      <p class="text-sm text-white/75">
-        Sprint offers: {promoOffer.sprintOffers.map((offer) => offer.displayName).join(', ')}
-      </p>
-    </div>
-
     <div class="grid gap-5">
-      {packageTiers.map((pkg) => (
+      <h2 class="font-display text-2xl text-white">Sprint offers</h2>
+      {promoOffer.sprintOffers.map((pkg) => (
         <article class="content-card space-y-4">
           <div class="flex flex-wrap items-center justify-between gap-3">
-            <p class="text-xs uppercase tracking-[0.35em] text-rose-petal/70">{pkg.label} tier</p>
+            <p class="text-xs uppercase tracking-[0.35em] text-rose-petal/70">Sprint</p>
             <a
               class="inline-flex items-center justify-center rounded-full border border-rose-gold/50 bg-rose-gold/15 px-4 py-2 text-xs uppercase tracking-[0.3em] text-rose-petal transition hover:border-rose-gold/70 hover:bg-rose-gold/30"
-              href={buildApplyHref(pkg.slug)}
+              href={buildApplyHref(pkg.id)}
             >
-              {t(lang, 'packages.cta')} ({pkg.label})
+              {t(lang, 'packages.cta')}
             </a>
           </div>
-          <h2 class="font-display text-2xl text-white">{pkg.name}</h2>
-          <div class="grid gap-4 sm:grid-cols-3">
+          <h3 class="font-display text-2xl text-white">{pkg.displayName}</h3>
+          <p class="text-sm text-white/70">{pkg.price} · {pkg.timeline}</p>
+          <div class="grid gap-4 sm:grid-cols-2">
             <div class="rounded-2xl border border-white/10 bg-black/20 p-4">
-              <h3 class="text-xs uppercase tracking-[0.25em] text-rose-petal/70">What you get</h3>
+              <h4 class="text-xs uppercase tracking-[0.25em] text-rose-petal/70">Deliverables</h4>
               <ul class="mt-3 space-y-2 text-sm text-white/75">
                 {pkg.deliverables.map((item) => (
                   <li>{item}</li>
@@ -118,17 +86,9 @@ const faqItems = [
               </ul>
             </div>
             <div class="rounded-2xl border border-white/10 bg-black/20 p-4">
-              <h3 class="text-xs uppercase tracking-[0.25em] text-rose-petal/70">Model provides</h3>
+              <h4 class="text-xs uppercase tracking-[0.25em] text-rose-petal/70">Model provides</h4>
               <ul class="mt-3 space-y-2 text-sm text-white/75">
-                {pkg.modelProvides.map((item) => (
-                  <li>{item}</li>
-                ))}
-              </ul>
-            </div>
-            <div class="rounded-2xl border border-white/10 bg-black/20 p-4">
-              <h3 class="text-xs uppercase tracking-[0.25em] text-rose-petal/70">What we do not do</h3>
-              <ul class="mt-3 space-y-2 text-sm text-white/75">
-                {pkg.weDoNotDo.map((item) => (
+                {pkg.gates.map((item) => (
                   <li>{item}</li>
                 ))}
               </ul>
@@ -136,6 +96,62 @@ const faqItems = [
           </div>
         </article>
       ))}
+
+      <h2 class="font-display text-2xl text-white">Monthly tiers</h2>
+      {promoOffer.monthlyTiers.map((pkg) => (
+        <article class="content-card space-y-4">
+          <div class="flex flex-wrap items-center justify-between gap-3">
+            <p class="text-xs uppercase tracking-[0.35em] text-rose-petal/70">Monthly</p>
+            <a
+              class="inline-flex items-center justify-center rounded-full border border-rose-gold/50 bg-rose-gold/15 px-4 py-2 text-xs uppercase tracking-[0.3em] text-rose-petal transition hover:border-rose-gold/70 hover:bg-rose-gold/30"
+              href={buildApplyHref(pkg.id)}
+            >
+              {t(lang, 'packages.cta')}
+            </a>
+          </div>
+          <h3 class="font-display text-2xl text-white">{pkg.displayName}</h3>
+          <p class="text-sm text-white/70">{pkg.price} · {pkg.timeline}</p>
+          <div class="grid gap-4 sm:grid-cols-2">
+            <div class="rounded-2xl border border-white/10 bg-black/20 p-4">
+              <h4 class="text-xs uppercase tracking-[0.25em] text-rose-petal/70">Deliverables</h4>
+              <ul class="mt-3 space-y-2 text-sm text-white/75">
+                {pkg.deliverables.map((item) => (
+                  <li>{item}</li>
+                ))}
+              </ul>
+            </div>
+            <div class="rounded-2xl border border-white/10 bg-black/20 p-4">
+              <h4 class="text-xs uppercase tracking-[0.25em] text-rose-petal/70">Model provides</h4>
+              <ul class="mt-3 space-y-2 text-sm text-white/75">
+                {pkg.gates.map((item) => (
+                  <li>{item}</li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </article>
+      ))}
+
+      <h2 class="font-display text-2xl text-white">Add-ons</h2>
+      <div class="grid gap-4 sm:grid-cols-2">
+        {promoOffer.addOns.map((addOn) => (
+          <article class="content-card space-y-3">
+            <div class="flex items-start justify-between gap-3">
+              <div>
+                <h3 class="font-display text-xl text-white">{addOn.name}</h3>
+                <p class="text-sm text-white/70">{addOn.price}</p>
+              </div>
+              <a
+                class="inline-flex items-center justify-center rounded-full border border-rose-gold/50 bg-rose-gold/15 px-4 py-2 text-xs uppercase tracking-[0.3em] text-rose-petal transition hover:border-rose-gold/70 hover:bg-rose-gold/30"
+                href={buildApplyHref(addOn.id)}
+              >
+                {t(lang, 'packages.cta')}
+              </a>
+            </div>
+            <p class="text-sm text-white/75">{addOn.description}</p>
+          </article>
+        ))}
+      </div>
     </div>
   </section>
 

--- a/tests/packages-page.test.mjs
+++ b/tests/packages-page.test.mjs
@@ -9,14 +9,14 @@ const resolveFixturePath = (relativePath) =>
 
 const readSource = async (relativePath) => fs.readFile(resolveFixturePath(relativePath), 'utf8');
 
-test('Packages page lists three mobile-scannable tiers', async () => {
+test('Packages page renders promoOffer sprint, monthly, and add-ons sections', async () => {
   const source = await readSource('src/pages/packages.astro');
-  assert.ok(source.includes('Starter Plan'), 'Packages page should include Starter tier');
-  assert.ok(source.includes('Growth Plan'), 'Packages page should include Growth tier');
-  assert.ok(source.includes('Pro Plan'), 'Packages page should include Pro tier');
-  assert.ok(source.includes('What you get'), 'Packages page should include what-you-get section');
-  assert.ok(source.includes('Model provides'), 'Packages page should include model-provided section');
-  assert.ok(source.includes('What we do not do'), 'Packages page should include limitations section');
+  assert.ok(source.includes('Sprint offers'), 'Packages page should include sprint offers section');
+  assert.ok(source.includes('promoOffer.sprintOffers.map'), 'Packages page should render sprint offers from promoOffer');
+  assert.ok(source.includes('Monthly tiers'), 'Packages page should include monthly tiers section');
+  assert.ok(source.includes('promoOffer.monthlyTiers.map'), 'Packages page should render monthly tiers from promoOffer');
+  assert.ok(source.includes('Add-ons'), 'Packages page should include add-ons section');
+  assert.ok(source.includes('promoOffer.addOns.map'), 'Packages page should render add-ons from promoOffer');
 });
 
 test('Packages page keeps trust policy and apply CTAs explicit', async () => {
@@ -24,5 +24,5 @@ test('Packages page keeps trust policy and apply CTAs explicit', async () => {
   assert.ok(source.includes('no passwords'), 'Packages page should state no passwords');
   assert.ok(source.includes('no exclusivity'), 'Packages page should state no exclusivity');
   assert.ok(source.includes('you own accounts and content'), 'Packages page should state ownership policy');
-  assert.ok(source.includes('/apply/'), 'Packages page should include apply links');
+  assert.ok(source.includes('/apply/promo'), 'Packages page should include promo apply links');
 });


### PR DESCRIPTION
### Motivation
- Restore mergeability for the packages page by keeping the promoOffer-driven implementation that renders Sprint, Monthly, and Add-ons from the canonical `promoOffer` data.  
- Ensure CTAs and trust policy remain explicit and match the product behavior expected by tests and reviewers.

### Description
- Updated `src/pages/packages.astro` to remove the inline `packageTiers` constant and render `promoOffer.sprintOffers`, `promoOffer.monthlyTiers`, and `promoOffer.addOns` directly.  
- Changed apply links to build the CTA URL as `/apply/promo?package=<id>` via `buildApplyHref`, and wired each CTA to use the `id` from the promo data.  
- Kept `promoOffer.nonNegotables` visible in the trust policy section and preserved platform scope output.  
- Adjusted `tests/packages-page.test.mjs` to validate the new promoOffer-backed sections and the `/apply/promo` CTA path and renamed the test to reflect the promoOffer rendering expectations.

### Testing
- Ran `npm test` and all tests passed (`82/82` passing).  
- Ran `npm run build` and the static site build completed successfully (80 pages built).  
- Branch could not be published from this execution environment because no upstream is configured here, so please push the local branch to the repository to refresh the PR and confirm mergeability on GitHub.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1f2b60630832685fde73ce04d8a89)