### PR TITLE
#122 Tighten homepage CTAs + nav for promo

### DIFF
--- a/src/data/nav.ts
+++ b/src/data/nav.ts
@@ -9,6 +9,7 @@ export type NavLink = {
 export const NAV_PRIMARY: NavLink[] = [
   { href: '/', label: 'Home' },
   { href: '/packages/', label: 'Packages' },
+  { href: '/apply/', label: 'Apply' },
   { href: '/platforms/', label: 'Platforms' },
   { href: '/resources/', label: 'Resources' },
   { href: '/proof/', label: 'Proof' }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -23,13 +23,13 @@ const websiteJsonLd = {
 ---
 
 <MainLayout
-  title="NaughtyCamSpot | Signup Help (Free) + Promotion (Paid)"
-  description="Start with Signup Help (Free), add Promotion (Paid) when ready, and keep full account ownership."
+  title="NaughtyCamSpot | Promotion (Paid) + Signup Help (Free)"
+  description="Start with Promotion (Paid), add Signup Help (Free) when needed, and keep full account ownership."
 >
   <SEO
     slot="head"
-    title="NaughtyCamSpot | Signup Help (Free) + Promotion (Paid)"
-    description="Choose Signup Help (Free), Promotion (Paid), or both. No passwords, no exclusivity, and full account ownership."
+    title="NaughtyCamSpot | Promotion (Paid) + Signup Help (Free)"
+    description="Choose Promotion (Paid), apply fast, or use Signup Help (Free). No passwords/logins, no exclusivity, and full account ownership."
     path={canonicalPath}
     ogImage="https://images.unsplash.com/photo-1517841905240-472988babdf9?auto=format&fit=crop&w=1280&q=80"
   />

--- a/src/partials/home/Hero.astro
+++ b/src/partials/home/Hero.astro
@@ -6,7 +6,7 @@ const { lang: langProp = 'en' } = Astro.props as { lang?: string };
 const lang = normalizeLang(langProp);
 const trustPromises = [
   {
-    title: 'No passwords',
+    title: 'No passwords/logins',
     reason: 'You keep your login private. We guide by approved files only.'
   },
   {
@@ -14,12 +14,20 @@ const trustPromises = [
     reason: 'You can choose other work paths. You stay in control.'
   },
   {
-    title: 'Model owns accounts',
-    reason: 'Your accounts and payouts stay yours. We do not take ownership.'
+    title: 'Model owns accounts/content',
+    reason: 'Your accounts, content, and payouts stay yours. We do not take ownership.'
+  },
+  {
+    title: 'No spam DM automation',
+    reason: 'We do not run spammy DM bots or mass message automation on your behalf.'
   },
   {
     title: 'Cancel anytime',
     reason: 'You can stop when needed. There is no lock-in contract.'
+  },
+  {
+    title: 'No earnings guarantees',
+    reason: 'Results vary and we do not promise specific income outcomes.'
   }
 ] as const;
 ---
@@ -42,18 +50,24 @@ const trustPromises = [
         <div class="flex flex-col gap-3 sm:flex-row sm:items-center">
           <LinkCTA
             class="inline-flex border border-rose-gold/70 bg-rose-gold px-6 py-3 text-lg text-midnight shadow-glow"
-            pagesHref="/recruiting/"
-            prodHref="/recruiting/"
-            label={t(lang, 'home.hero.cta.signup')}
+            pagesHref="/packages/"
+            prodHref="/packages/"
+            label={t(lang, 'home.hero.cta.promo')}
           />
           <LinkCTA
             class="inline-flex border border-white/20 bg-transparent px-6 py-3 text-lg text-white transition hover:border-white/40 hover:bg-white/5"
-            pagesHref="/promotion/"
-            prodHref="/promotion/"
-            label={t(lang, 'home.hero.cta.promo')}
+            pagesHref="/apply/promo"
+            prodHref="/apply/promo"
+            label="Apply for Promotion"
           />
         </div>
         <p class="max-w-2xl text-sm text-white/70">Signup Help (Free) and Promotion (Paid) are separate tracks. Use one or combine both.</p>
+        <a
+          class="inline-flex w-fit rounded-full border border-white/20 px-4 py-2 text-xs uppercase tracking-[0.3em] text-white/70 transition hover:border-white/40 hover:text-white"
+          href="/apply/signup"
+        >
+          Need Signup Help (Free)?
+        </a>
         <a
           class="text-xs uppercase tracking-[0.35em] text-white/60 transition hover:text-rose-gold"
           href="/proof/"
@@ -70,9 +84,7 @@ const trustPromises = [
             </details>
           ))}
         </div>
-        <p class="max-w-xl text-[clamp(0.78rem,1.4vw,0.9rem)] text-white/60">
-          Not an agency or studio. No earnings guarantee. We earn only from partner signups.
-        </p>
+        <p class="max-w-xl text-[clamp(0.78rem,1.4vw,0.9rem)] text-white/60">Not an agency or studio. We earn only from partner signups.</p>
       </div>
       <div class="grid">
         <div class="relative overflow-hidden rounded-[34px] border border-white/10 bg-white/5 p-6 backdrop-blur shadow-glow">

--- a/tests/accessibility-readability.test.mjs
+++ b/tests/accessibility-readability.test.mjs
@@ -25,8 +25,7 @@ test('Navigation semantics include explicit labels and resources controls', asyn
 
 test('Navigation labels remain title/sentence case', async () => {
   const source = await readSource('src/data/nav.ts');
-  ['Home', 'Packages', 'Platforms', 'Resources', 'Proof'].forEach((label) => {
+  ['Home', 'Packages', 'Apply', 'Platforms', 'Resources', 'Proof'].forEach((label) => {
     assert.ok(source.includes(`label: '${label}'`), `Expected nav label ${label}`);
   });
-  assert.ok(!source.includes("label: 'Apply'"), 'Expected Apply to be removed from text navigation');
 });

--- a/tests/home-hero-cta.test.mjs
+++ b/tests/home-hero-cta.test.mjs
@@ -15,12 +15,12 @@ test('Primary CTA routes to Apply in all environments', async () => {
   assert.ok(copySource.includes("prodHref: '/apply'"), 'Production href should point to /apply');
 });
 
-test('Hero partial renders signup help + promotion CTAs', async () => {
+test('Hero partial renders promo-first CTA stack', async () => {
   const heroSource = await readSource('src/partials/home/Hero.astro');
-  assert.ok(heroSource.includes("home.hero.cta.signup"), 'Hero partial should reference the signup help CTA translation key');
-  assert.ok(heroSource.includes('/recruiting/'), 'Hero partial should link to /recruiting/');
   assert.ok(heroSource.includes("home.hero.cta.promo"), 'Hero partial should reference the promotion CTA translation key');
-  assert.ok(heroSource.includes('/promotion/'), 'Hero partial should link to /promotion/');
+  assert.ok(heroSource.includes('/packages/'), 'Hero partial should link primary CTA to /packages/');
+  assert.ok(heroSource.includes('/apply/promo'), 'Hero partial should include secondary CTA to /apply/promo');
+  assert.ok(heroSource.includes('/apply/signup'), 'Hero partial should include tertiary signup help link');
 });
 
 test('Hero partial avoids tracked /go/ links', async () => {

--- a/tests/homepage.spec.ts
+++ b/tests/homepage.spec.ts
@@ -9,7 +9,7 @@ const readBlogIndex = (mode: 'pages' | 'prod') => readOutputFile(mode, ['blog', 
 describe('Homepage routing', () => {
   it('builds the homepage at the root without v2 prefixes', async () => {
     const { html } = await readHome('prod');
-    expect(html).toContain('NaughtyCamSpot | Signup Help (Free) + Promotion (Paid)');
+    expect(html).toContain('NaughtyCamSpot | Promotion (Paid) + Signup Help (Free)');
     expect(html).not.toContain('/v2/');
   }, BUILD_TIMEOUT);
 

--- a/tests/navigation-structure.test.mjs
+++ b/tests/navigation-structure.test.mjs
@@ -16,10 +16,11 @@ test('Primary navigation includes core funnel top-level links', async () => {
   assert.ok(navSource.includes("label: 'Platforms'"), 'Primary navigation should include Platforms');
   assert.ok(navSource.includes("label: 'Resources'"), 'Primary navigation should include Resources');
   assert.ok(navSource.includes("label: 'Proof'"), 'Primary navigation should include Proof');
-  assert.ok(!navSource.includes("label: 'Apply'"), 'Primary navigation should not include Apply');
+  assert.ok(navSource.includes("label: 'Apply'"), 'Primary navigation should include Apply');
   assert.ok(!navSource.includes("label: 'How It Works'"), 'Primary navigation should not include How It Works');
   assert.ok(navSource.includes("href: '/'"), 'Primary navigation should point Home to /');
   assert.ok(navSource.includes("href: '/packages/'"), 'Primary navigation should point Packages to /packages/');
+  assert.ok(navSource.includes("href: '/apply/'"), 'Primary navigation should point Apply to /apply/');
   assert.ok(navSource.includes("href: '/platforms/'"), 'Primary navigation should point Platforms to /platforms/');
   assert.ok(navSource.includes("href: '/resources/'"), 'Primary navigation should point Resources to /resources/');
   assert.ok(navSource.includes("href: '/proof/'"), 'Primary navigation should point Proof to /proof/');
@@ -54,6 +55,7 @@ test('Navigation links map to existing routes', async () => {
   const knownRouteSet = new Set([
     '/',
     '/packages/',
+    '/apply/',
     '/platforms/',
     '/resources/',
     '/proof/'


### PR DESCRIPTION
### Motivation
- Prioritize Promotion (paid) as the primary funnel for a promo launch while keeping Signup Help (free) clearly available as a secondary path.
- Surface an explicit near-hero trust/non-negotiables block so visitors see non-negotiable policy points upfront.
- Ensure the top navigation exposes the Apply entry and routes consistently to the existing `/apply` chooser and related apply pages.

### Description
- Updated the hero CTA stack in `src/partials/home/Hero.astro` so the primary CTA now links to `/packages/`, the secondary CTA links to `/apply/promo`, and a visible tertiary link points to `/apply/signup`.
- Expanded the near-hero trust bullets in `src/partials/home/Hero.astro` to list: `No passwords/logins`, `No exclusivity`, `Model owns accounts/content`, `No spam DM automation`, `Cancel anytime`, and `No earnings guarantees`.
- Adjusted homepage metadata/title/SEO framing in `src/pages/index.astro` to a promo-first message while preserving ownership/trust language.
- Added `Apply` to the primary navigation in `src/data/nav.ts` mapped to `/apply/` and left existing core items intact.
- Updated only the tests that depended on the previous CTA/nav expectations (`tests/home-hero-cta.test.mjs`, `tests/navigation-structure.test.mjs`, `tests/accessibility-readability.test.mjs`, and `tests/homepage.spec.ts`) to reflect the new routes and title.

### Testing
- Ran `npm test` and all automated tests passed (83 tests passed, 0 failed).
- Ran `npm run build` and the static site built successfully (82 pages built, build completed without errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1fb75562c8326b1588a584a399629)