### PR TITLE
#124 Align promo platform scope

### DIFF
--- a/src/data/promoOffer.ts
+++ b/src/data/promoOffer.ts
@@ -14,12 +14,19 @@ type PromoAddOn = {
   description: string;
 };
 
+export type PromoPlatformScopeEntry = {
+  id: string;
+  name: string;
+  status: 'live' | 'coming-soon';
+};
+
 export const promoOffer: {
   sprintOffers: PromoPlan[];
   monthlyTiers: PromoPlan[];
   addOns: PromoAddOn[];
   nonNegotables: string[];
   platformScope: {
+    platforms: PromoPlatformScopeEntry[];
     live: string[];
     comingSoon: string[];
   };
@@ -103,6 +110,12 @@ export const promoOffer: {
     'No earnings guarantees'
   ],
   platformScope: {
+    platforms: [
+      { id: 'chaturbate', name: 'Chaturbate', status: 'live' },
+      { id: 'camsoda', name: 'CamSoda', status: 'live' },
+      { id: 'bongacams', name: 'BongaCams', status: 'live' },
+      { id: 'stripchat', name: 'Stripchat', status: 'coming-soon' }
+    ],
     live: ['Chaturbate', 'CamSoda', 'BongaCams'],
     comingSoon: ['Stripchat']
   }

--- a/src/pages/apply/promo.astro
+++ b/src/pages/apply/promo.astro
@@ -2,11 +2,13 @@
 import MainLayout from '../../layouts/MainLayout.astro';
 import SEO from '../../components/SEO.astro';
 import { withBase } from '../../utils/links';
+import { promoOffer } from '../../data/promoOffer';
 
 const canonicalPath = '/apply/promo';
 const packageSelected = Astro.url.searchParams.get('package') ?? '';
 const formAction = withBase('/claim/index.php');
 const csrfEndpoint = withBase('/claim/token.php');
+const promoPlatforms = promoOffer.platformScope.platforms;
 ---
 
 <MainLayout title="Apply for Promotion | NaughtyCamSpot" description="Promotion intake form.">
@@ -37,10 +39,19 @@ const csrfEndpoint = withBase('/claim/token.php');
 
       <fieldset class="space-y-2 rounded-2xl border border-white/10 bg-white/5 p-4">
         <legend class="px-1 text-xs uppercase tracking-[0.28em] text-white/70">Platforms</legend>
-        <label class="block text-sm text-white/80"><input class="mr-2" type="checkbox" name="platform_interest[]" value="chaturbate" /> chaturbate</label>
-        <label class="block text-sm text-white/80"><input class="mr-2" type="checkbox" name="platform_interest[]" value="camsoda" /> camsoda</label>
-        <label class="block text-sm text-white/80"><input class="mr-2" type="checkbox" name="platform_interest[]" value="bongacams" /> bongacams</label>
-        <label class="block text-sm text-white/50"><input class="mr-2" type="checkbox" disabled /> stripchat (coming soon)</label>
+        {promoPlatforms.map((platform) => (
+          <label class={`block text-sm ${platform.status === 'live' ? 'text-white/80' : 'text-white/50'}`}>
+            <input
+              class="mr-2"
+              type="checkbox"
+              name="platform_interest[]"
+              value={platform.id}
+              disabled={platform.status !== 'live'}
+            />
+            {platform.name}
+            {platform.status !== 'live' ? ' (coming soon)' : ''}
+          </label>
+        ))}
       </fieldset>
 
       <fieldset class="space-y-2 rounded-2xl border border-white/10 bg-white/5 p-4">

--- a/src/pages/platforms.astro
+++ b/src/pages/platforms.astro
@@ -1,7 +1,7 @@
 ---
 import MainLayout from '../layouts/MainLayout.astro';
 import SEO from '../components/SEO.astro';
-import { PLATFORMS } from '../data/platforms';
+import { promoOffer } from '../data/promoOffer';
 import { isPagesBuild, withBase } from '../utils/links';
 import { getRequestLang, t } from '../i18n/core';
 
@@ -21,27 +21,28 @@ const resolveHostname = (value: string | undefined) => {
 const siteHostname = resolveHostname(import.meta.env.SITE as string | undefined);
 const isProdSite = siteHostname === 'naughtycamspot.com';
 const useGoLinks = !isPagesBuild() && isProdSite;
+const platformNotes: Record<string, string> = {
+  chaturbate: 'High traffic, long-tail tipping, and recurring fan rooms.',
+  camsoda: 'Quality-focused traffic with strong contests and promo placements.',
+  bongacams: 'Great geo diversification with steady discovery opportunities.',
+  stripchat: 'Launch prep is underway. Join promo intake to get notified first.'
+};
 const statusMeta = {
-  open: {
-    label: 'Open',
+  live: {
+    label: 'Live',
     meaning: 'Join now',
     className: 'border-emerald-300/50 bg-emerald-400/20 text-emerald-100',
     icon: 'check'
   },
-  limited: {
-    label: 'Limited',
-    meaning: 'Request slot',
-    className: 'border-amber-300/50 bg-amber-400/20 text-amber-100',
-    icon: 'clock'
-  },
-  waitlist: {
+  'coming-soon': {
     label: 'Coming soon',
     meaning: 'Notify me',
     className: 'border-slate-300/40 bg-slate-400/20 text-slate-100',
     icon: 'hourglass'
   }
 } as const;
-const legendStatuses = ['open', 'limited', 'waitlist'] as const;
+const legendStatuses = ['live', 'coming-soon'] as const;
+const promoPlatforms = promoOffer.platformScope.platforms;
 ---
 
 <MainLayout
@@ -109,11 +110,13 @@ const legendStatuses = ['open', 'limited', 'waitlist'] as const;
     </div>
 
     <div class="grid gap-6 lg:grid-cols-2">
-      {PLATFORMS.map((platform) => {
-        const meta = statusMeta[platform.status] ?? statusMeta.waitlist;
-        const href = useGoLinks ? platform.goPath : withBase('/apply');
-        const target = useGoLinks ? '_blank' : undefined;
-        const rel = useGoLinks ? 'noopener noreferrer' : undefined;
+      {promoPlatforms.map((platform) => {
+        const meta = statusMeta[platform.status] ?? statusMeta['coming-soon'];
+        const goPath = `/go/${platform.id}`;
+        const href = platform.status === 'coming-soon' ? withBase('/apply/promo') : (useGoLinks ? goPath : withBase('/apply'));
+        const target = platform.status === 'live' && useGoLinks ? '_blank' : undefined;
+        const rel = platform.status === 'live' && useGoLinks ? 'noopener noreferrer' : undefined;
+        const note = platformNotes[platform.id] ?? 'Platform support details available during application review.';
         return (
           <article class="content-card space-y-4">
             <div class="flex items-center justify-between">
@@ -138,13 +141,13 @@ const legendStatuses = ['open', 'limited', 'waitlist'] as const;
                 <span>{meta.label}</span>
               </span>
             </div>
-            <p class="text-sm text-white/70">{platform.note}</p>
+            <p class="text-sm text-white/70">{note}</p>
             <details class="rounded-2xl border border-white/10 bg-black/20 p-4">
               <summary class="cursor-pointer text-xs font-semibold uppercase tracking-[0.22em] text-rose-petal focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-gold">
                 Details
               </summary>
               <div class="mt-3 space-y-2 text-sm text-white/75">
-                <p><span class="text-white/55">Best for:</span> Creators who want {platform.note.toLowerCase()}</p>
+                <p><span class="text-white/55">Best for:</span> Creators who want {note.toLowerCase()}</p>
                 <p><span class="text-white/55">Needs:</span> A complete profile and quick message replies.</p>
                 <p><span class="text-white/55">Next:</span> {meta.meaning}. Use the button below.</p>
               </div>
@@ -155,10 +158,10 @@ const legendStatuses = ['open', 'limited', 'waitlist'] as const;
                 href={href}
                 target={target}
                 rel={rel}
-                data-platform={platform.slug}
-                data-preclick={useGoLinks ? '1' : undefined}
-                data-go-href={useGoLinks ? platform.goPath : undefined}
-                data-platform-id={platform.slug}
+                data-platform={platform.id}
+                data-preclick={platform.status === 'live' && useGoLinks ? '1' : undefined}
+                data-go-href={platform.status === 'live' && useGoLinks ? goPath : undefined}
+                data-platform-id={platform.id}
                 data-platform-name={platform.name}
               >
                 Open next step

--- a/tests/promo-platform-alignment.test.mjs
+++ b/tests/promo-platform-alignment.test.mjs
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { test } from 'node:test';
+
+const resolveFixturePath = (relativePath) =>
+  path.join(path.dirname(fileURLToPath(import.meta.url)), '..', relativePath);
+
+const readSource = async (relativePath) => fs.readFile(resolveFixturePath(relativePath), 'utf8');
+
+test('Apply promo platform checkboxes render from promoOffer and keep coming soon disabled', async () => {
+  const source = await readSource('src/pages/apply/promo.astro');
+  assert.ok(source.includes('promoOffer.platformScope.platforms'), 'Apply promo page should use promoOffer canonical platform scope');
+  assert.ok(source.includes('name="platform_interest[]"'), 'Apply promo page should keep platform_interest[] fields');
+  assert.ok(source.includes('disabled={platform.status !== \'live\'}'), 'Only live promo platforms should be selectable');
+  assert.ok(source.includes("(coming soon)"), 'Coming soon promo platform should be visibly labeled');
+});
+
+test('Platforms page renders promo scope from promoOffer with coming soon routing to promo apply', async () => {
+  const source = await readSource('src/pages/platforms.astro');
+  assert.ok(source.includes('promoOffer.platformScope.platforms'), 'Platforms page should use promoOffer canonical platform scope');
+  assert.ok(source.includes("platform.status === 'coming-soon' ? withBase('/apply/promo')"), 'Coming soon platforms should route to promo apply CTA');
+});


### PR DESCRIPTION
### Motivation
- Ensure promo UI uses a single canonical platform list so promo platform availability is consistent across pages.
- Explicitly mark which platforms are `live` (selectable) versus `coming-soon` (disabled) so Stripchat is shown but not selectable while remaining discoverable.
- Prevent duplicated/hardcoded promo platform arrays in promo-related UI by centralizing the scope in the promo data model.

### Description
- Add a typed canonical promo platform list `platforms` to `promoOffer.platformScope` with entries `{ id, name, status }` and populate it for Chaturbate, CamSoda, BongaCams (`live`) and Stripchat (`coming-soon`) in `src/data/promoOffer.ts`.
- Update `src/pages/apply/promo.astro` to render platform checkboxes from `promoOffer.platformScope.platforms`, keep the `name="platform_interest[]"` fields for form submission, and disable non-live platforms with a visible “(coming soon)” label.
- Update `src/pages/platforms.astro` to render platform cards from the canonical promo scope, show `Live` / `Coming soon` badges, route live CTAs to `/go/<id>` when allowed, and route coming-soon CTAs to `/apply/promo`.
- Add a focused test `tests/promo-platform-alignment.test.mjs` to assert the apply and platforms pages consume the canonical promo scope and that coming-soon items are disabled/routed appropriately.

### Testing
- Ran `npm test` which executed the node test suite and vitest, and all tests passed (85 tests passed including the new alignment test).
- Ran `npm run build` which completed the Astro build and generated the static pages successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a20088a0548326ae71ab584df07aab)