### PR TITLE
Add Model Signup Help (Free) issue sequence to ISSUES_ORDER.md

### DIFF
--- a/ISSUES_ORDER.md
+++ b/ISSUES_ORDER.md
@@ -20,6 +20,24 @@ This file is the prioritized execution queue for the **Promo-ready launch plan**
 7. **#138 AI-Fulfilled Model Growth Ops positioning pass (copy-only)**  
    Copy/layout-only pass on index/packages/proof to justify higher pricing; no routing or data model changes.
 
+## Model Signup Help (Free) sequence
+1. **#TBD Signup: Create canonical “Signup Help (Free)” landing page**  
+   Create one canonical funnel entry point with clear step-by-step signup flow and proof guidance. Reuse canonical platform data and keep contacts limited to Telegram + Email.
+2. **#TBD Signup: Proof submission instructions (make “send proof” unambiguous)**  
+   Standardize a single reusable proof-copy block and apply it consistently on signup pages.
+3. **#TBD Signup: Platforms page becomes signup-first and consistent**  
+   Align `/platforms` CTAs and status messaging with signup-first flow and canonical platform metadata.
+4. **#TBD Signup: StartRight page restructure for signup conversion**  
+   Reframe `/startright` around post-proof value, checklist, and strong signup funnel CTAs.
+5. **#TBD Signup: Earnings page supports signup decision (not a dead end)**  
+   Add clear top/bottom signup CTAs while preserving no-guarantee posture.
+6. **#TBD Signup: Audit and align /go endpoints for signup flow**  
+   Ensure live platform IDs and `/go/<id>` redirects are aligned and used as the only outbound path.
+
+## Backlog
+- **#TBD Signup+Promo: Add more contact options beyond Telegram + Email**  
+  Add WhatsApp and at least one additional contact channel to promo and signup intake (separate from this execution queue).
+
 ## Notes
 - One issue per PR. Run `npm test` and `npm run build` and fix failures before moving to the next issue.
 - No refactors outside issue scope (no type renames across the repo, no “cleanup”).


### PR DESCRIPTION
### Motivation
- Introduce a dedicated, ordered execution queue for the Model Signup Help (Free) funnel immediately after the existing promo/phase sections so signup work is planned and visible. 
- Keep scope tightly focused on signup content/funnel only, reuse canonical platform data, and limit contact methods to Telegram + Email for this execution batch.

### Description
- Added a new “Model Signup Help (Free) sequence” section to `ISSUES_ORDER.md` with six ordered signup issues (A–F) marked `#TBD` for issue numbers. 
- Added a separate “Backlog” entry for the multi-contact expansion issue (Issue G) explicitly outside the main execution queue. 
- Preserved all existing promo/phase sections and notes; no other files were modified.

### Testing
- Confirmed `/signup-help` does not currently exist via a filesystem check (expected for later implementation). 
- Verified the repository diff shows only `ISSUES_ORDER.md` changed and the new section is present. 
- Attempted automated GitHub issue creation via the API, but requests failed in this environment (HTTP 403/000), so issue numbers remain `#TBD` and must be created from an authenticated environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a220b948bc83269a2e72fe07269bd8)